### PR TITLE
Fix. Rename module name from `Rubocop' to `RuboCop' as per the upstream ...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ RSpec::Core::RakeTask.new(:unit)
 
 require 'rubocop/rake_task'
 desc 'Run Ruby style checks'
-Rubocop::RakeTask.new(:style)
+RuboCop::RakeTask.new(:style)
 
 begin
   require 'yard'


### PR DESCRIPTION
...change.

This concerns the following commit:

  https://github.com/bbatsov/rubocop/commit/ff167d8f202baf7a68955db0aaf0dc29afb7e7ee

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
