### PR TITLE
Require Ruby 2.2 and use chefstyle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,0 @@
-Lint/DuplicatedKey:
-  Exclude:
-    - 'spec/mixlib/versioning/versioning_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,22 +1,3 @@
-AbcSize:
-  Enabled: false
-BracesAroundHashParameters:
-  Enabled: false
-ClassLength:
-  Enabled: false
-CyclomaticComplexity:
-  Enabled: false
-Documentation:
-  Enabled: false
-Encoding:
-  Enabled: false
-LineLength:
-  Enabled: false
-MethodLength:
-  Enabled: false
-PerceivedComplexity:
-  Enabled: false
-RescueModifier:
-  Enabled: false
-TrailingComma:
-  EnforcedStyleForMultiline: comma
+Lint/DuplicatedKey:
+  Exclude:
+    - 'spec/mixlib/versioning/versioning_spec.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,10 @@
+language: ruby
+cache: bundler
+sudo: false
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-
-bundler_args: --jobs 7
-
+- 2.2.5
+- 2.3.1
 branches:
   only:
     - master
-
 script: bundle exec rake travis:ci
-
-notifications:
-  hipchat:
-    on_change: true
-    on_failure: true
-    on_success: false
-    on_pull_requests: false
-    rooms:
-      # Build Statuses
-      - secure: IycrY52k8dhilnU3B2c8mem9LzofQlMISUZSDk2tys0cvW0U3lnCQQiSvT5kTtiKztUABEiT2UqU2QYwUfeW/yYrO3NjB2OBqehRKnEn2oEaapcIugvtsQMySfYqJ7IsKpyh3vTMmgyKPw3OCKh5OJn26lMdHH2R91SXcbUezKI=
-      # Release Engineering
-      - secure: JJlujHzKxsY74bfJHNxH6fQOF5IULeJECXkxx6uU/T+CjxydINwAH5lQ1RUleLZlH0BmQDgxK+O46hiuWdYAyhgCJY9bQOBWG+aQusXIoLvV3qj+rU0dX1wvjEuO/NzkZTPZy7HMGqmCxTdmx/OawoNnpXU8qsI/OJqbISv2bGo=

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec
 
 group :docs do
-  gem 'yard',          '~> 0.8'
-  gem 'redcarpet',     '~> 2.2'
-  gem 'github-markup', '~> 0.7'
+  gem "yard",          "~> 0.8"
+  gem "redcarpet",     "~> 2.2"
+  gem "github-markup", "~> 0.7"
 end

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 # Mixlib::Versioning
 
-[![Build Status](https://travis-ci.org/chef/mixlib-versioning.png?branch=master)](https://travis-ci.org/chef/mixlib-versioning)
-[![Code Climate](https://codeclimate.com/github/chef/mixlib-versioning.png)](https://codeclimate.com/github/chef/mixlib-versioning)
+[![Build Status](https://travis-ci.org/chef/mixlib-versioning.svg?branch=master)](https://travis-ci.org/chef/mixlib-versioning) [![Code Climate](https://codeclimate.com/github/chef/mixlib-versioning.svg)](https://codeclimate.com/github/chef/mixlib-versioning)
 
 This project is managed by the CHEF Release Engineering team. For more information on the Release Engineering team's contribution, triage, and release process, please consult the [CHEF Release Engineering OSS Management Guide](https://docs.google.com/a/chef.io/document/d/1oJB0vZb_3bl7_ZU2YMDBkMFdL-EWplW1BJv_FXTUOzg/edit).
 
-Versioning is hard! `mixlib-versioning` is a general Ruby library that allows
-you to parse, compare and manipulate version numbers in multiple formats.
-Currently the following version string formats are supported:
+Versioning is hard! `mixlib-versioning` is a general Ruby library that allows you to parse, compare and manipulate version numbers in multiple formats. Currently the following version string formats are supported:
 
-### SemVer 2.0.0
+## SemVer 2.0.0
 
 **Specification:**
 
-http://semver.org/
+<http://semver.org/>
 
 **Supported Formats:**
 
@@ -23,10 +20,9 @@ MAJOR.MINOR.PATCH-PRERELEASE
 MAJOR.MINOR.PATCH-PRERELEASE+BUILD
 ```
 
-Not much to say here except: *YUNO USE SEMVER!* The specification is focused and
-brief, do yourself a favor and go read it.
+Not much to say here except: _YUNO USE SEMVER!_ The specification is focused and brief, do yourself a favor and go read it.
 
-### Opscode SemVer
+## Opscode SemVer
 
 **Supported Formats:**
 
@@ -43,11 +39,9 @@ MAJOR.MINOR.PATCH-beta.INDEX+YYYYMMDDHHMMSS.git.COMMITS_SINCE.SHA1
 MAJOR.MINOR.PATCH-rc.INDEX+YYYYMMDDHHMMSS.git.COMMITS_SINCE.SHA1
 ```
 
-All the fun of regular SemVer with some extra limits around what constitutes a
-valid pre-release or build version string.
+All the fun of regular SemVer with some extra limits around what constitutes a valid pre-release or build version string.
 
-Valid prerelease version strings use the format: `PRERELEASE_STAGE.INDEX`.
-Valid prerelease stages include: `alpha`, `beta` and `rc`.
+Valid prerelease version strings use the format: `PRERELEASE_STAGE.INDEX`. Valid prerelease stages include: `alpha`, `beta` and `rc`.
 
 All of the following are acceptable Opscode SemVer pre-release versions:
 
@@ -60,9 +54,7 @@ All of the following are acceptable Opscode SemVer pre-release versions:
 11.0.8-rc.2
 ```
 
-Build version strings are limited to timestamps (`YYYYMMDDHHMMSS`), git
-describe strings (`git.COMMITS_SINCE.SHA1`) or a combination of the two
-(`YYYYMMDDHHMMSS.git.COMMITS_SINCE.SHA1`).
+Build version strings are limited to timestamps (`YYYYMMDDHHMMSS`), git describe strings (`git.COMMITS_SINCE.SHA1`) or a combination of the two (`YYYYMMDDHHMMSS.git.COMMITS_SINCE.SHA1`).
 
 All of the following are acceptable Opscode build versions:
 
@@ -79,13 +71,13 @@ And as is true with regular SemVer you can mix pre-release and build versions:
 11.0.8-alpha.2+20130308110833.git.2.94a1dde
 ```
 
-### Rubygems
+## Rubygems
 
 **specification:**
 
-http://docs.rubygems.org/read/chapter/7
+<http://docs.rubygems.org/read/chapter/7>
 
-http://guides.rubygems.org/patterns/
+<http://guides.rubygems.org/patterns/>
 
 **Supported Formats:**
 
@@ -94,9 +86,7 @@ MAJOR.MINOR.PATCH
 MAJOR.MINOR.PATCH.PRERELEASE
 ```
 
-Rubygems is *almost* SemVer compliant but it separates the main version from
-the pre-release version using a "dot". It also does not have the notion of a
-build version like SemVer.
+Rubygems is _almost_ SemVer compliant but it separates the main version from the pre-release version using a "dot". It also does not have the notion of a build version like SemVer.
 
 Examples of valid Rubygems version strings:
 
@@ -108,11 +98,11 @@ Examples of valid Rubygems version strings:
 10.1.1.rc.0
 ```
 
-### Git Describe
+## Git Describe
 
 **Specification:**
 
-http://git-scm.com/docs/git-describe
+<http://git-scm.com/docs/git-describe>
 
 **Supported Formats:**
 
@@ -136,15 +126,21 @@ Examples of valid Git Describe version strings:
 
 Add this line to your application's Gemfile:
 
-    gem 'mixlib-versioning'
+```
+gem 'mixlib-versioning'
+```
 
 And then execute:
 
-    $ bundle
+```
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install mixlib-semver
+```
+$ gem install mixlib-semver
+```
 
 ## Usage
 
@@ -336,15 +332,20 @@ All documentation is written using YARD. You can generate a by running:
 rake yard
 ```
 
+## Contributing
+
+For information on contributing to this project see <https://github.com/chef/chef/blob/master/CONTRIBUTING.md>
+
 ## License
 
 |                      |                                          |
 |:---------------------|:-----------------------------------------|
 | **Author:**          | Seth Chisamore (schisamo@chef.io)
 | **Author:**          | Christopher Maier (cm@chef.io)
-| **Copyright:**       | Copyright (c) 2013 Opscode, Inc.
+| **Copyright:**       | Copyright (c) 2013-2016 Chef Software, Inc.
 | **License:**         | Apache License, Version 2.0
 
+```text
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -356,3 +357,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,18 @@
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"
 
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:unit)
 
-require 'rubocop/rake_task'
-desc 'Run Ruby style checks'
+require "chefstyle"
+require "rubocop/rake_task"
+desc "Run Ruby style checks"
 RuboCop::RakeTask.new(:style)
 
-require 'yard'
+require "yard"
 YARD::Rake::YardocTask.new(:doc)
 
 namespace :travis do
-  desc 'Run tests on Travis'
+  desc "Run tests on Travis"
   task ci: [:style, :unit]
 end
 

--- a/lib/mixlib/versioning.rb
+++ b/lib/mixlib/versioning.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require 'mixlib/versioning/exceptions'
-require 'mixlib/versioning/format'
+require "mixlib/versioning/exceptions"
+require "mixlib/versioning/format"
 
 module Mixlib
   # @author Seth Chisamore (<schisamo@chef.io>)
@@ -135,7 +135,7 @@ module Mixlib
       # attempt to parse a `Mixlib::Versioning::Format` instance if we were
       # passed a string
       unless filter_version.nil? ||
-             filter_version.is_a?(Mixlib::Versioning::Format)
+          filter_version.is_a?(Mixlib::Versioning::Format)
         filter_version = Mixlib::Versioning.parse(filter_version)
       end
 
@@ -181,13 +181,13 @@ module Mixlib
           in_release_line && if use_prerelease_versions && use_build_versions
                                v.prerelease_build?
                              elsif !use_prerelease_versions &&
-                                   use_build_versions
+                                 use_build_versions
                                v.release_build?
                              elsif use_prerelease_versions &&
-                                   !use_build_versions
+                                 !use_build_versions
                                v.prerelease?
                              elsif !use_prerelease_versions &&
-                                   !use_build_versions
+                                 !use_build_versions
                                v.release?
                              end
         end.max # select the most recent version

--- a/lib/mixlib/versioning/format.rb
+++ b/lib/mixlib/versioning/format.rb
@@ -16,10 +16,10 @@
 # limitations under the License.
 #
 
-require 'mixlib/versioning/format/git_describe'
-require 'mixlib/versioning/format/opscode_semver'
-require 'mixlib/versioning/format/rubygems'
-require 'mixlib/versioning/format/semver'
+require "mixlib/versioning/format/git_describe"
+require "mixlib/versioning/format/opscode_semver"
+require "mixlib/versioning/format/rubygems"
+require "mixlib/versioning/format/semver"
 
 module Mixlib
   class Versioning
@@ -60,17 +60,17 @@ module Mixlib
       #
       def self.for(format_type)
         if format_type.is_a?(Class) &&
-           format_type.ancestors.include?(Mixlib::Versioning::Format)
+            format_type.ancestors.include?(Mixlib::Versioning::Format)
           format_type
         else
           case format_type.to_s
-          when 'semver' then Mixlib::Versioning::Format::SemVer
-          when 'opscode_semver' then Mixlib::Versioning::Format::OpscodeSemVer
-          when 'git_describe' then Mixlib::Versioning::Format::GitDescribe
-          when 'rubygems' then Mixlib::Versioning::Format::Rubygems
+          when "semver" then Mixlib::Versioning::Format::SemVer
+          when "opscode_semver" then Mixlib::Versioning::Format::OpscodeSemVer
+          when "git_describe" then Mixlib::Versioning::Format::GitDescribe
+          when "rubygems" then Mixlib::Versioning::Format::Rubygems
           else
             msg = "'#{format_type}' is not a supported Mixlib::Versioning format"
-            fail Mixlib::Versioning::UnknownFormatError, msg
+            raise Mixlib::Versioning::UnknownFormatError, msg
           end
         end
       end
@@ -90,7 +90,7 @@ module Mixlib
       # @param version_string [String] string representation of the version
       # @raise [Mixlib::Versioning::ParseError] raised if parsing fails
       def parse(_version_string)
-        fail Error, 'You must override the #parse'
+        raise Error, "You must override the #parse"
       end
 
       # @return [Boolean] Whether or not this is a release version
@@ -153,7 +153,7 @@ module Mixlib
         vars = instance_variables.map do |n|
           "#{n}=#{instance_variable_get(n).inspect}"
         end
-        format('#<%s:0x%x %s>', self.class, object_id, vars.join(', '))
+        format("#<%s:0x%x %s>", self.class, object_id, vars.join(", "))
       end
 
       # Returns SemVer compliant string representation of this {Format}
@@ -167,7 +167,7 @@ module Mixlib
       #   {Format} instance
       # @todo create a proper serialization abstraction
       def to_semver_string
-        s = [@major, @minor, @patch].join('.')
+        s = [@major, @minor, @patch].join(".")
         s += "-#{@prerelease}" if @prerelease
         s += "+#{@build}" if @build
         s
@@ -184,7 +184,7 @@ module Mixlib
       #   {Format} instance
       # @todo create a proper serialization abstraction
       def to_rubygems_string
-        s = [@major, @minor, @patch].join('.')
+        s = [@major, @minor, @patch].join(".")
         s += ".#{@prerelease}" if @prerelease
         s
       end
@@ -269,7 +269,7 @@ module Mixlib
       end
 
       def hash
-        [@major, @minor, @patch, @prerelease, @build].compact.join('.').hash
+        [@major, @minor, @patch, @prerelease, @build].compact.join(".").hash
       end
 
       #########################################################################
@@ -303,8 +303,8 @@ module Mixlib
       # Both `a_item` and `b_item` should be Strings; `nil` is not a
       # valid input.
       def compare_dot_components(a_item, b_item)
-        a_components = a_item.split('.')
-        b_components = b_item.split('.')
+        a_components = a_item.split(".")
+        b_components = b_item.split(".")
 
         max_length = [a_components.length, b_components.length].max
 

--- a/lib/mixlib/versioning/format/git_describe.rb
+++ b/lib/mixlib/versioning/format/git_describe.rb
@@ -53,7 +53,7 @@ module Mixlib
           match = version_string.match(GIT_DESCRIBE_REGEX) rescue nil
 
           unless match
-            fail Mixlib::Versioning::ParseError, "'#{version_string}' is not a valid #{self.class} version string!"
+            raise Mixlib::Versioning::ParseError, "'#{version_string}' is not a valid #{self.class} version string!"
           end
 
           @major, @minor, @patch, @prerelease, @commits_since, @commit_sha, @iteration = match[1..7]

--- a/lib/mixlib/versioning/format/opscode_semver.rb
+++ b/lib/mixlib/versioning/format/opscode_semver.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require 'mixlib/versioning/format/semver'
+require "mixlib/versioning/format/semver"
 
 module Mixlib
   class Versioning
@@ -71,8 +71,8 @@ module Mixlib
         def parse(version_string)
           super(version_string)
 
-          fail Mixlib::Versioning::ParseError, "'#{@prerelease}' is not a valid Opscode pre-release signifier!" unless @prerelease.nil? || @prerelease.match(OPSCODE_PRERELEASE_REGEX)
-          fail Mixlib::Versioning::ParseError, "'#{@build}' is not a valid Opscode build signifier!" unless @build.nil? || @build.match(OPSCODE_BUILD_REGEX)
+          raise Mixlib::Versioning::ParseError, "'#{@prerelease}' is not a valid Opscode pre-release signifier!" unless @prerelease.nil? || @prerelease.match(OPSCODE_PRERELEASE_REGEX)
+          raise Mixlib::Versioning::ParseError, "'#{@build}' is not a valid Opscode build signifier!" unless @build.nil? || @build.match(OPSCODE_BUILD_REGEX)
         end
       end # class OpscodeSemVer
     end # class Format

--- a/lib/mixlib/versioning/format/rubygems.rb
+++ b/lib/mixlib/versioning/format/rubygems.rb
@@ -49,7 +49,7 @@ module Mixlib
           match = version_string.match(RUBYGEMS_REGEX) rescue nil
 
           unless match
-            fail Mixlib::Versioning::ParseError, "'#{version_string}' is not a valid #{self.class} version string!"
+            raise Mixlib::Versioning::ParseError, "'#{version_string}' is not a valid #{self.class} version string!"
           end
 
           @major, @minor, @patch, @prerelease, @iteration = match[1..5]

--- a/lib/mixlib/versioning/format/semver.rb
+++ b/lib/mixlib/versioning/format/semver.rb
@@ -49,7 +49,7 @@ module Mixlib
           match = version_string.match(SEMVER_REGEX) rescue nil
 
           unless match
-            fail Mixlib::Versioning::ParseError, "'#{version_string}' is not a valid #{self.class} version string!"
+            raise Mixlib::Versioning::ParseError, "'#{version_string}' is not a valid #{self.class} version string!"
           end
 
           @major, @minor, @patch, @prerelease, @build = match[1..5]

--- a/lib/mixlib/versioning/version.rb
+++ b/lib/mixlib/versioning/version.rb
@@ -18,6 +18,6 @@
 
 module Mixlib
   class Versioning
-    VERSION = '1.1.0'
+    VERSION = "1.1.0"
   end
 end

--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chef/mixlib-versioning'
   spec.license       = 'Apache 2.0'
 
-  spec.required_ruby_version = '>= 1.9'
+  spec.required_ruby_version = ">= 2.2"
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -1,28 +1,28 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'mixlib/versioning/version'
+require "mixlib/versioning/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'mixlib-versioning'
+  spec.name          = "mixlib-versioning"
   spec.version       = Mixlib::Versioning::VERSION
-  spec.authors       = ['Seth Chisamore', 'Christopher Maier']
-  spec.email         = ['schisamo@chef.io', 'cm@chef.io']
-  spec.description   = 'General purpose Ruby library that allows you to parse, compare and manipulate version strings in multiple formats.'
+  spec.authors       = ["Seth Chisamore", "Christopher Maier"]
+  spec.email         = ["schisamo@chef.io", "cm@chef.io"]
+  spec.description   = "General purpose Ruby library that allows you to parse, compare and manipulate version strings in multiple formats."
   spec.summary       = spec.description
-  spec.homepage      = 'https://github.com/chef/mixlib-versioning'
-  spec.license       = 'Apache 2.0'
+  spec.homepage      = "https://github.com/chef/mixlib-versioning"
+  spec.license       = "Apache 2.0"
 
   spec.required_ruby_version = ">= 2.2"
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
   # Development dependencies
-  spec.add_development_dependency 'rubocop', '= 0.31.0'
-  spec.add_development_dependency 'rspec',   '~> 2.14'
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency "chefstyle", "= 0.4.0"
+  spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 end

--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   # Development dependencies
   spec.add_development_dependency "chefstyle", "= 0.4.0"
-  spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "rspec", "< 2.99"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end

--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Development dependencies
-  spec.add_development_dependency "chefstyle", "= 0.4.0"
+  spec.add_development_dependency "chefstyle"
   spec.add_development_dependency "rspec", "< 2.99"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/spec/mixlib/versioning/format/git_describe_spec.rb
+++ b/spec/mixlib/versioning/format/git_describe_spec.rb
@@ -16,103 +16,103 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Mixlib::Versioning::Format::GitDescribe do
   subject { described_class.new(version_string) }
 
-  it_has_behavior 'parses valid version strings', {
-    '0.10.8-231-g59d6185' => {
+  it_has_behavior "parses valid version strings", {
+    "0.10.8-231-g59d6185" => {
       major: 0,
       minor: 10,
       patch: 8,
       prerelease: nil,
-      build: '231.g59d6185.0',
+      build: "231.g59d6185.0",
       release?: false,
       prerelease?: false,
       build?: true,
       release_build?: true,
       prerelease_build?: false,
       commits_since: 231,
-      commit_sha: '59d6185',
+      commit_sha: "59d6185",
       iteration: 0,
     },
-    '10.16.2-49-g21353f0-1' => {
+    "10.16.2-49-g21353f0-1" => {
       major: 10,
       minor: 16,
       patch: 2,
       prerelease: nil,
-      build: '49.g21353f0.1',
+      build: "49.g21353f0.1",
       release?: false,
       prerelease?: false,
       build?: true,
       release_build?: true,
       prerelease_build?: false,
       commits_since: 49,
-      commit_sha: '21353f0',
+      commit_sha: "21353f0",
       iteration: 1,
     },
-    '10.16.2.rc.1-49-g21353f0-1' => {
+    "10.16.2.rc.1-49-g21353f0-1" => {
       major: 10,
       minor: 16,
       patch: 2,
-      prerelease: 'rc.1',
-      build: '49.g21353f0.1',
+      prerelease: "rc.1",
+      build: "49.g21353f0.1",
       release?: false,
       prerelease?: false,
       build?: true,
       release_build?: false,
       prerelease_build?: true,
       commits_since: 49,
-      commit_sha: '21353f0',
+      commit_sha: "21353f0",
       iteration: 1,
     },
-    '10.16.2-alpha-49-g21353f0-1' => {
+    "10.16.2-alpha-49-g21353f0-1" => {
       major: 10,
       minor: 16,
       patch: 2,
-      prerelease: 'alpha',
-      build: '49.g21353f0.1',
+      prerelease: "alpha",
+      build: "49.g21353f0.1",
       release?: false,
       prerelease?: false,
       build?: true,
       release_build?: false,
       prerelease_build?: true,
       commits_since: 49,
-      commit_sha: '21353f0',
+      commit_sha: "21353f0",
       iteration: 1,
     },
-    '10.16.2-alpha-49-g21353f0' => {
+    "10.16.2-alpha-49-g21353f0" => {
       major: 10,
       minor: 16,
       patch: 2,
-      prerelease: 'alpha',
-      build: '49.g21353f0.0',
+      prerelease: "alpha",
+      build: "49.g21353f0.0",
       release?: false,
       prerelease?: false,
       build?: true,
       release_build?: false,
       prerelease_build?: true,
       commits_since: 49,
-      commit_sha: '21353f0',
+      commit_sha: "21353f0",
       iteration: 0,
     },
   }
 
-  it_has_behavior 'rejects invalid version strings', {
-    '1.0.0' => 'no git describe data',
-    '1.0.0-alpha.1' => 'no git describe data',
-    '1.0.0-alpha.1+build.deadbeef' => 'no git describe data',
-    '1.0.0-123-gfd0e3a65282cb5f6df3bab6a53f4fcb722340d499-1' => 'too many SHA1 characters',
-    '1.0.0-123-gdeadbe-1' => 'too few SHA1 characters',
-    '1.0.0-123-gNOTHEX1-1' => 'illegal SHA1 characters',
-    '1.0.0-123-g1234567-alpha' => 'non-numeric iteration',
-    '1.0.0-alpha-poop-g1234567-1' => "non-numeric 'commits_since'",
-    '1.0.0-g1234567-1' => "missing 'commits_since'",
-    '1.0.0-123-1' => 'missing SHA1',
+  it_has_behavior "rejects invalid version strings", {
+    "1.0.0" => "no git describe data",
+    "1.0.0-alpha.1" => "no git describe data",
+    "1.0.0-alpha.1+build.deadbeef" => "no git describe data",
+    "1.0.0-123-gfd0e3a65282cb5f6df3bab6a53f4fcb722340d499-1" => "too many SHA1 characters",
+    "1.0.0-123-gdeadbe-1" => "too few SHA1 characters",
+    "1.0.0-123-gNOTHEX1-1" => "illegal SHA1 characters",
+    "1.0.0-123-g1234567-alpha" => "non-numeric iteration",
+    "1.0.0-alpha-poop-g1234567-1" => "non-numeric 'commits_since'",
+    "1.0.0-g1234567-1" => "missing 'commits_since'",
+    "1.0.0-123-1" => "missing SHA1",
   }
 
-  version_strings = %w(
+  version_strings = %w{
     9.0.1-1-gdeadbee-1
     9.1.2-2-g1234567-1
     10.0.0-1-gabcdef3-1
@@ -123,14 +123,14 @@ describe Mixlib::Versioning::Format::GitDescribe do
     9.0.1-2-gdeadbe1-2
     9.0.1-2-gdeadbe2-1
     9.1.1-2-g1234567-1
-  )
+  }
 
-  it_has_behavior 'serializable', version_strings
+  it_has_behavior "serializable", version_strings
 
-  it_has_behavior 'sortable' do
+  it_has_behavior "sortable" do
     let(:unsorted_version_strings) { version_strings }
     let(:sorted_version_strings) do
-      %w(
+      %w{
         9.0.1-1-gdeadbee-1
         9.0.1-2-gdeadbe1-1
         9.0.1-2-gdeadbe1-2
@@ -141,17 +141,17 @@ describe Mixlib::Versioning::Format::GitDescribe do
         10.5.7-2-g21353f0-1
         10.20.2-2-gbbbbbbb-1
         10.20.2-3-gaaaaaaa-1
-      )
+      }
     end
-    let(:min) { '9.0.1-1-gdeadbee-1' }
-    let(:max) { '10.20.2-3-gaaaaaaa-1' }
+    let(:min) { "9.0.1-1-gdeadbee-1" }
+    let(:max) { "10.20.2-3-gaaaaaaa-1" }
   end # it_has_behavior
 
   # The +GitDescribe+ format only produces release build versions.
-  it_has_behavior 'filterable' do
+  it_has_behavior "filterable" do
     let(:unsorted_version_strings) { version_strings }
     let(:build_versions) do
-      %w(
+      %w{
         9.0.1-1-gdeadbee-1
         9.1.2-2-g1234567-1
         10.0.0-1-gabcdef3-1
@@ -162,10 +162,10 @@ describe Mixlib::Versioning::Format::GitDescribe do
         9.0.1-2-gdeadbe1-2
         9.0.1-2-gdeadbe2-1
         9.1.1-2-g1234567-1
-      )
+      }
     end
     let(:release_build_versions) do
-      %w(
+      %w{
         9.0.1-1-gdeadbee-1
         9.1.2-2-g1234567-1
         10.0.0-1-gabcdef3-1
@@ -176,15 +176,15 @@ describe Mixlib::Versioning::Format::GitDescribe do
         9.0.1-2-gdeadbe1-2
         9.0.1-2-gdeadbe2-1
         9.1.1-2-g1234567-1
-      )
+      }
     end
-  end  # it_has_behavior
+  end # it_has_behavior
 
-  it_has_behavior 'comparable', [
-    '9.0.1-1-gdeadbee-1', '9.0.1-2-gdeadbe1-1',
-    '9.0.1-2-gdeadbe1-2', '9.0.1-2-gdeadbe2-1',
-    '9.1.1-2-g1234567-1', '9.1.2-2-g1234567-1',
-    '10.0.0-1-gabcdef3-1', '10.5.7-2-g21353f0-1',
-    '10.20.2-2-gbbbbbbb-1', '10.20.2-3-gaaaaaaa-1'
+  it_has_behavior "comparable", [
+    "9.0.1-1-gdeadbee-1", "9.0.1-2-gdeadbe1-1",
+    "9.0.1-2-gdeadbe1-2", "9.0.1-2-gdeadbe2-1",
+    "9.1.1-2-g1234567-1", "9.1.2-2-g1234567-1",
+    "10.0.0-1-gabcdef3-1", "10.5.7-2-g21353f0-1",
+    "10.20.2-2-gbbbbbbb-1", "10.20.2-3-gaaaaaaa-1"
   ]
 end # describe

--- a/spec/mixlib/versioning/format/opscode_semver_spec.rb
+++ b/spec/mixlib/versioning/format/opscode_semver_spec.rb
@@ -16,38 +16,38 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Mixlib::Versioning::Format::OpscodeSemVer do
   subject { described_class.new(version_string) }
 
   it_should_behave_like Mixlib::Versioning::Format::SemVer
 
-  it_has_behavior 'rejects invalid version strings', {
-    '1.0.0-poop.0' => 'non-valid pre-release type',
-    '1.0.0+2010AA08010101' => 'a malformed timestamp',
-    '1.0.0+cvs.33.e0f985a' => 'a malformed git describe: no git string',
-    '1.0.0+git.AA.e0f985a' => 'a malformed git describe: non-numeric COMMITS_SINCE',
-    '1.0.0+git.33.z0f985a' => 'a malformed git describe: invalid SHA1',
-    '11.0.08-rc.1+20130308110833' => 'leading zero invalid',
-    '01.0.8-alpha.2+20130308110833.git.2.94a1dde' => 'leading zero invalid',
-    '11.02.8-rc.1+20130308110833' => 'leading zero invalid',
-    '0008.1.4' => 'leading zero invalid',
-    '11.00000000002.8-rc.1+20130308110833' => 'leading zero invalid',
-    '4.67.00012+build.20131219' => 'leading zero invalid',
-    '3.6.7-rc.007' => 'leading zero invalid',
+  it_has_behavior "rejects invalid version strings", {
+    "1.0.0-poop.0" => "non-valid pre-release type",
+    "1.0.0+2010AA08010101" => "a malformed timestamp",
+    "1.0.0+cvs.33.e0f985a" => "a malformed git describe: no git string",
+    "1.0.0+git.AA.e0f985a" => "a malformed git describe: non-numeric COMMITS_SINCE",
+    "1.0.0+git.33.z0f985a" => "a malformed git describe: invalid SHA1",
+    "11.0.08-rc.1+20130308110833" => "leading zero invalid",
+    "01.0.8-alpha.2+20130308110833.git.2.94a1dde" => "leading zero invalid",
+    "11.02.8-rc.1+20130308110833" => "leading zero invalid",
+    "0008.1.4" => "leading zero invalid",
+    "11.00000000002.8-rc.1+20130308110833" => "leading zero invalid",
+    "4.67.00012+build.20131219" => "leading zero invalid",
+    "3.6.7-rc.007" => "leading zero invalid",
   }
 
-  it_has_behavior 'serializable', [
-    '1.0.0',
-    '1.0.0-alpha.1',
-    '1.0.0-alpha.1+20130308110833',
-    '1.0.0+20130308110833.git.2.94a1dde',
+  it_has_behavior "serializable", [
+    "1.0.0",
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.1+20130308110833",
+    "1.0.0+20130308110833.git.2.94a1dde",
   ]
 
-  it_has_behavior 'sortable' do
+  it_has_behavior "sortable" do
     let(:unsorted_version_strings) do
-      %w(
+      %w{
         1.0.0-beta.2
         1.0.0-alpha
         1.0.0-rc.1+20130309074433
@@ -59,10 +59,10 @@ describe Mixlib::Versioning::Format::OpscodeSemVer do
         1.3.7+20131009104433.git.2.94a1dde
         1.3.7+20131009104433
         1.3.7+20131009074433
-      )
+      }
     end
     let(:sorted_version_strings) do
-      %w(
+      %w{
         1.0.0-alpha
         1.0.0-alpha.1
         1.0.0-beta.2
@@ -74,15 +74,15 @@ describe Mixlib::Versioning::Format::OpscodeSemVer do
         1.3.7+20131009074433
         1.3.7+20131009104433
         1.3.7+20131009104433.git.2.94a1dde
-      )
+      }
     end
-    let(:min) { '1.0.0-alpha' }
-    let(:max) { '1.3.7+20131009104433.git.2.94a1dde' }
+    let(:min) { "1.0.0-alpha" }
+    let(:max) { "1.3.7+20131009104433.git.2.94a1dde" }
   end # it_has_behavior
 
-  it_has_behavior 'filterable' do
+  it_has_behavior "filterable" do
     let(:unsorted_version_strings) do
-      %w(
+      %w{
         1.0.0-beta.2
         1.0.0-alpha
         1.0.0-rc.1+20130309074433
@@ -94,45 +94,45 @@ describe Mixlib::Versioning::Format::OpscodeSemVer do
         1.3.7+20131009104433.git.2.94a1dde
         1.3.7+20131009104433
         1.3.7+20131009074433
-      )
+      }
     end
-    let(:release_versions) { %w(1.0.0) }
+    let(:release_versions) { %w{1.0.0} }
     let(:prerelease_versions) do
-      %w(
+      %w{
         1.0.0-beta.2
         1.0.0-alpha
         1.0.0-beta.11
         1.0.0-rc.1
         1.0.0-alpha.1
-      )
+      }
     end
     let(:build_versions) do
-      %w(
+      %w{
         1.0.0-rc.1+20130309074433
         1.0.0+20121009074433
         1.3.7+20131009104433.git.2.94a1dde
         1.3.7+20131009104433
         1.3.7+20131009074433
-      )
+      }
     end
     let(:release_build_versions) do
-      %w(
+      %w{
         1.0.0+20121009074433
         1.3.7+20131009104433.git.2.94a1dde
         1.3.7+20131009104433
         1.3.7+20131009074433
-      )
+      }
     end
     let(:prerelease_build_versions) do
-      %w(
-        1.0.0-rc.1+20130309074433      )
+      %w{
+        1.0.0-rc.1+20130309074433      }
     end
   end # it_has_behavior
 
-  it_has_behavior 'comparable', [
-    '0.1.0', '0.2.0',
-    '1.0.0-alpha.1', '1.0.0',
-    '1.2.3', '1.2.3+20121009074433',
-    '2.0.0-beta.1', '2.0.0+20131009104433.git.2.94a1dde'
+  it_has_behavior "comparable", [
+    "0.1.0", "0.2.0",
+    "1.0.0-alpha.1", "1.0.0",
+    "1.2.3", "1.2.3+20121009074433",
+    "2.0.0-beta.1", "2.0.0+20131009104433.git.2.94a1dde"
   ]
 end # describe

--- a/spec/mixlib/versioning/format/rubygems_spec.rb
+++ b/spec/mixlib/versioning/format/rubygems_spec.rb
@@ -16,15 +16,15 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Mixlib::Versioning::Format::Rubygems do
   subject { described_class.new(version_string) }
 
-  it_should_behave_like 'Basic SemVer'
+  it_should_behave_like "Basic SemVer"
 
-  it_has_behavior 'parses valid version strings', {
-    '10.1.1' => {
+  it_has_behavior "parses valid version strings", {
+    "10.1.1" => {
       major: 10,
       minor: 1,
       patch: 1,
@@ -37,11 +37,11 @@ describe Mixlib::Versioning::Format::Rubygems do
       prerelease_build?: false,
       iteration: 0,
     },
-    '10.1.1.alpha.1' => {
+    "10.1.1.alpha.1" => {
       major: 10,
       minor: 1,
       patch: 1,
-      prerelease: 'alpha.1',
+      prerelease: "alpha.1",
       build: nil,
       release?: false,
       prerelease?: true,
@@ -50,11 +50,11 @@ describe Mixlib::Versioning::Format::Rubygems do
       prerelease_build?: false,
       iteration: 0,
     },
-    '11.0.8.rc.3' => {
+    "11.0.8.rc.3" => {
       major: 11,
       minor: 0,
       patch: 8,
-      prerelease: 'rc.3',
+      prerelease: "rc.3",
       build: nil,
       release?: false,
       prerelease?: true,
@@ -63,7 +63,7 @@ describe Mixlib::Versioning::Format::Rubygems do
       prerelease_build?: false,
       iteration: 0,
     },
-    '11.0.8-33' => {
+    "11.0.8-33" => {
       major: 11,
       minor: 0,
       patch: 8,
@@ -76,11 +76,11 @@ describe Mixlib::Versioning::Format::Rubygems do
       prerelease_build?: false,
       iteration: 33,
     },
-    '11.0.8.rc.3-1' => {
+    "11.0.8.rc.3-1" => {
       major: 11,
       minor: 0,
       patch: 8,
-      prerelease: 'rc.3',
+      prerelease: "rc.3",
       build: nil,
       release?: false,
       prerelease?: true,
@@ -91,67 +91,67 @@ describe Mixlib::Versioning::Format::Rubygems do
     },
   }
 
-  it_has_behavior 'rejects invalid version strings', {
-    '1.1.1-rutro' => 'dash for pre-release delimeter',
+  it_has_behavior "rejects invalid version strings", {
+    "1.1.1-rutro" => "dash for pre-release delimeter",
   }
 
-  it_has_behavior 'serializable', [
-    '1.0.0',
-    '1.0.0.alpha.1',
-    '1.0.0.beta',
+  it_has_behavior "serializable", [
+    "1.0.0",
+    "1.0.0.alpha.1",
+    "1.0.0.beta",
   ]
 
-  it_has_behavior 'sortable' do
+  it_has_behavior "sortable" do
     let(:unsorted_version_strings) do
-      %w(
+      %w{
         1.0.0.beta.2
         1.3.7.alpha.0
         1.0.0.alpha
         1.0.0.rc.1
         1.0.0
-      )
+      }
     end
     let(:sorted_version_strings) do
-      %w(
+      %w{
         1.0.0.alpha
         1.0.0.beta.2
         1.0.0.rc.1
         1.0.0
         1.3.7.alpha.0
-      )
+      }
     end
-    let(:min) { '1.0.0.alpha' }
-    let(:max) { '1.3.7.alpha.0' }
+    let(:min) { "1.0.0.alpha" }
+    let(:max) { "1.3.7.alpha.0" }
   end
 
   # The +Rubygems+ format only produces release and prerelease versions.
-  it_has_behavior 'filterable' do
+  it_has_behavior "filterable" do
     let(:unsorted_version_strings) do
-      %w(
+      %w{
         1.0.0.beta.2
         1.3.7.alpha.0
         1.0.0.alpha
         1.0.0.rc.1
         1.0.0
-      )
+      }
     end
-    let(:release_versions) { %w(1.0.0) }
+    let(:release_versions) { %w{1.0.0} }
     let(:prerelease_versions) do
-      %w(
+      %w{
         1.0.0.beta.2
         1.3.7.alpha.0
         1.0.0.alpha
         1.0.0.rc.1
-      )
+      }
     end
   end
 
-  it_has_behavior 'comparable', [
-    '0.1.0', '0.2.0',
-    '1.0.0.alpha.1', '1.0.0',
-    '1.2.3.alpha', '1.2.3.alpha.1',
-    '2.4.5.alpha', '2.4.5.beta',
-    '3.0.0.beta.1', '3.0.0.rc.1',
-    '3.1.2.rc.42', '3.1.2'
+  it_has_behavior "comparable", [
+    "0.1.0", "0.2.0",
+    "1.0.0.alpha.1", "1.0.0",
+    "1.2.3.alpha", "1.2.3.alpha.1",
+    "2.4.5.alpha", "2.4.5.beta",
+    "3.0.0.beta.1", "3.0.0.rc.1",
+    "3.1.2.rc.42", "3.1.2"
   ]
 end

--- a/spec/mixlib/versioning/format/semver_spec.rb
+++ b/spec/mixlib/versioning/format/semver_spec.rb
@@ -16,23 +16,23 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Mixlib::Versioning::Format::SemVer do
   subject { described_class.new(version_string) }
 
   it_should_behave_like Mixlib::Versioning::Format::SemVer
 
-  it_has_behavior 'serializable', [
-    '1.0.0',
-    '1.0.0-alpha.1',
-    '1.0.0-alpha.1+some.build.version',
-    '1.0.0+build.build.build',
+  it_has_behavior "serializable", [
+    "1.0.0",
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.1+some.build.version",
+    "1.0.0+build.build.build",
   ]
 
-  it_has_behavior 'sortable' do
+  it_has_behavior "sortable" do
     let(:unsorted_version_strings) do
-      %w(
+      %w{
         1.0.0-beta.2
         1.0.0-alpha
         1.0.0-alpha.july
@@ -45,10 +45,10 @@ describe Mixlib::Versioning::Format::SemVer do
         1.3.7+build.2.b8f12d7
         1.3.7+build.11.e0f985a
         1.3.7+build
-      )
+      }
     end
     let(:sorted_version_strings) do
-      %w(
+      %w{
         1.0.0-alpha
         1.0.0-alpha.1
         1.0.0-alpha.july
@@ -61,15 +61,15 @@ describe Mixlib::Versioning::Format::SemVer do
         1.3.7+build
         1.3.7+build.2.b8f12d7
         1.3.7+build.11.e0f985a
-      )
+      }
     end
-    let(:min) { '1.0.0-alpha' }
-    let(:max) { '1.3.7+build.11.e0f985a' }
+    let(:min) { "1.0.0-alpha" }
+    let(:max) { "1.3.7+build.11.e0f985a" }
   end # it_has_behavior
 
-  it_has_behavior 'filterable' do
+  it_has_behavior "filterable" do
     let(:unsorted_version_strings) do
-      %w(
+      %w{
         1.0.0-beta.2
         1.0.0-alpha
         1.0.0-rc.1+build.1
@@ -81,48 +81,48 @@ describe Mixlib::Versioning::Format::SemVer do
         1.3.7+build.2.b8f12d7
         1.3.7+build.11.e0f985a
         1.3.7+build
-      )
+      }
     end
     let(:release_versions) do
-      %w(
-        1.0.0      )
+      %w{
+        1.0.0      }
     end
     let(:prerelease_versions) do
-      %w(
+      %w{
         1.0.0-beta.2
         1.0.0-alpha
         1.0.0-beta.11
         1.0.0-rc.1
         1.0.0-alpha.1
-      )
+      }
     end
     let(:build_versions) do
-      %w(
+      %w{
         1.0.0-rc.1+build.1
         1.0.0+0.3.7
         1.3.7+build.2.b8f12d7
         1.3.7+build.11.e0f985a
         1.3.7+build
-      )
+      }
     end
     let(:release_build_versions) do
-      %w(
+      %w{
         1.0.0+0.3.7
         1.3.7+build.2.b8f12d7
         1.3.7+build.11.e0f985a
         1.3.7+build
-      )
+      }
     end
     let(:prerelease_build_versions) do
-      %w(
-        1.0.0-rc.1+build.1      )
+      %w{
+        1.0.0-rc.1+build.1      }
     end
   end # it_has_behavior
 
-  it_has_behavior 'comparable', [
-    '0.1.0', '0.2.0',
-    '1.0.0-alpha.1', '1.0.0',
-    '1.2.3', '1.2.3+build.123',
-    '2.0.0-beta.1', '2.0.0-beta.1+build.123'
+  it_has_behavior "comparable", [
+    "0.1.0", "0.2.0",
+    "1.0.0-alpha.1", "1.0.0",
+    "1.2.3", "1.2.3+build.123",
+    "2.0.0-beta.1", "2.0.0-beta.1+build.123"
   ]
 end # describe

--- a/spec/mixlib/versioning/format_spec.rb
+++ b/spec/mixlib/versioning/format_spec.rb
@@ -16,42 +16,42 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Mixlib::Versioning::Format do
-  describe '#initialize' do
+  describe "#initialize" do
     subject { described_class.new(version_string) }
-    let(:version_string) { '11.0.0' }
+    let(:version_string) { "11.0.0" }
 
-    it 'descendants must override #parse' do
+    it "descendants must override #parse" do
       expect { subject }.to raise_error
     end
   end
 
-  describe '.for' do
+  describe ".for" do
     subject { described_class }
 
     [
       :rubygems,
-      'rubygems',
+      "rubygems",
       Mixlib::Versioning::Format::Rubygems,
     ].each do |format_type|
       context 'format_type is a: #{format_type.class}' do
         let(:format_type) { format_type }
-        it 'returns the correct format class' do
+        it "returns the correct format class" do
           subject.for(format_type).should eq Mixlib::Versioning::Format::Rubygems
         end # it
       end # context
     end # each
 
-    describe 'unknown format_type' do
+    describe "unknown format_type" do
       [
         :poop,
-        'poop',
+        "poop",
         Mixlib::Versioning,
       ].each do |invalid_format_type|
         context 'format_type is a: #{invalid_format_type.class}' do
-          it 'raises a Mixlib::Versioning::UnknownFormatError' do
+          it "raises a Mixlib::Versioning::UnknownFormatError" do
             expect { subject.for(invalid_format_type) }.to raise_error(Mixlib::Versioning::UnknownFormatError)
           end # it
         end # context

--- a/spec/mixlib/versioning/versioning_spec.rb
+++ b/spec/mixlib/versioning/versioning_spec.rb
@@ -16,33 +16,33 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Mixlib::Versioning do
   subject { described_class }
 
-  let(:version_string) { '11.0.0' }
+  let(:version_string) { "11.0.0" }
 
-  describe '.parse' do
-    describe 'parsing when format type is specified' do
+  describe ".parse" do
+    describe "parsing when format type is specified" do
       {
-        '11.0.8' => {
+        "11.0.8" => {
           format_type: :semver,
           expected_format: Mixlib::Versioning::Format::SemVer,
         },
-        '11.1.1' => {
+        "11.1.1" => {
           format_type: :rubygems,
           expected_format: Mixlib::Versioning::Format::Rubygems,
         },
-        '11.1.1.alpha.1' => {
+        "11.1.1.alpha.1" => {
           format_type: :rubygems,
           expected_format: Mixlib::Versioning::Format::Rubygems,
         },
-        '11.1.1-alpha.1' => {
+        "11.1.1-alpha.1" => {
           format_type: :opscode_semver,
           expected_format: Mixlib::Versioning::Format::OpscodeSemVer,
         },
-        '11.1.1-rc.2' => {
+        "11.1.1-rc.2" => {
           format_type: :opscode_semver,
           expected_format: Mixlib::Versioning::Format::SemVer,
         },
@@ -66,14 +66,14 @@ describe Mixlib::Versioning do
         end # context
       end # each_pair
 
-      describe 'invalid format type specified' do
+      describe "invalid format type specified" do
         [
           :poop,
-          'poop',
+          "poop",
           Mixlib::Versioning,
         ].each do |invalid_format_type|
           context "invalid format as a: #{invalid_format_type.class}" do
-            it 'raises a Mixlib::Versioning::UnknownFormatError' do
+            it "raises a Mixlib::Versioning::UnknownFormatError" do
               expect { subject.parse(version_string, invalid_format_type) }.to raise_error(Mixlib::Versioning::UnknownFormatError)
             end # it
           end # context
@@ -81,27 +81,27 @@ describe Mixlib::Versioning do
       end # describe
     end # describe
 
-    describe 'parsing with automatic format detection' do
+    describe "parsing with automatic format detection" do
       {
-        '11.0.8' => Mixlib::Versioning::Format::SemVer,
-        '11.0.8-1' => Mixlib::Versioning::Format::SemVer,
-        '11.0.8.rc.1' => Mixlib::Versioning::Format::Rubygems,
-        '11.0.8.rc.1-1' => Mixlib::Versioning::Format::Rubygems,
-        '11.0.8-rc.1' => Mixlib::Versioning::Format::OpscodeSemVer,
+        "11.0.8" => Mixlib::Versioning::Format::SemVer,
+        "11.0.8-1" => Mixlib::Versioning::Format::SemVer,
+        "11.0.8.rc.1" => Mixlib::Versioning::Format::Rubygems,
+        "11.0.8.rc.1-1" => Mixlib::Versioning::Format::Rubygems,
+        "11.0.8-rc.1" => Mixlib::Versioning::Format::OpscodeSemVer,
 
-        '10.18.2' => Mixlib::Versioning::Format::SemVer,
-        '10.18.2-poop' => Mixlib::Versioning::Format::SemVer,
-        '10.18.2.poop' => Mixlib::Versioning::Format::Rubygems,
-        '10.18.2.poop-1' => Mixlib::Versioning::Format::Rubygems,
+        "10.18.2" => Mixlib::Versioning::Format::SemVer,
+        "10.18.2-poop" => Mixlib::Versioning::Format::SemVer,
+        "10.18.2.poop" => Mixlib::Versioning::Format::Rubygems,
+        "10.18.2.poop-1" => Mixlib::Versioning::Format::Rubygems,
 
-        '12.1.1+20130311134422' => Mixlib::Versioning::Format::OpscodeSemVer,
-        '12.1.1-rc.3+20130311134422' => Mixlib::Versioning::Format::OpscodeSemVer,
-        '12.1.1+20130308110833.git.2.94a1dde' => Mixlib::Versioning::Format::OpscodeSemVer,
+        "12.1.1+20130311134422" => Mixlib::Versioning::Format::OpscodeSemVer,
+        "12.1.1-rc.3+20130311134422" => Mixlib::Versioning::Format::OpscodeSemVer,
+        "12.1.1+20130308110833.git.2.94a1dde" => Mixlib::Versioning::Format::OpscodeSemVer,
 
-        '10.16.2-49-g21353f0' => Mixlib::Versioning::Format::GitDescribe,
-        '10.16.2-49-g21353f0-1' => Mixlib::Versioning::Format::GitDescribe,
-        '10.16.2.rc.2-49-g21353f0' => Mixlib::Versioning::Format::GitDescribe,
-        '10.16.2-rc.2-49-g21353f0' => Mixlib::Versioning::Format::GitDescribe,
+        "10.16.2-49-g21353f0" => Mixlib::Versioning::Format::GitDescribe,
+        "10.16.2-49-g21353f0-1" => Mixlib::Versioning::Format::GitDescribe,
+        "10.16.2.rc.2-49-g21353f0" => Mixlib::Versioning::Format::GitDescribe,
+        "10.16.2-rc.2-49-g21353f0" => Mixlib::Versioning::Format::GitDescribe,
       }.each_pair do |version_string, expected_format|
         context version_string do
           let(:version_string) { version_string }
@@ -111,59 +111,59 @@ describe Mixlib::Versioning do
         end # context
       end # each_pair
 
-      describe 'version_string cannot be parsed' do
-        let(:version_string) { 'A.B.C' }
-        it 'returns nil' do
+      describe "version_string cannot be parsed" do
+        let(:version_string) { "A.B.C" }
+        it "returns nil" do
           subject.parse(version_string).should be_nil
         end
       end
     end # describe "parsing with automatic format detection"
 
-    describe 'parsing an Mixlib::Versioning::Format object' do
-      it 'returns the same object' do
+    describe "parsing an Mixlib::Versioning::Format object" do
+      it "returns the same object" do
         v = Mixlib::Versioning.parse(version_string)
         result = subject.parse(v)
         v.should be result
       end
     end
 
-    describe 'when formats are given' do
-      context 'when the format is not in the list' do
-        let(:version_string) { '10.16.2-rc.2-49-g21353f0' }
-        it 'returns nil when the array contains a Mixlib::Versioning::Format' do
+    describe "when formats are given" do
+      context "when the format is not in the list" do
+        let(:version_string) { "10.16.2-rc.2-49-g21353f0" }
+        it "returns nil when the array contains a Mixlib::Versioning::Format" do
           subject.parse(version_string, [Mixlib::Versioning::Format::Rubygems]).should be_nil
         end
 
-        it 'returns nil when the array contains a string' do
-          subject.parse(version_string, ['rubygems']).should be_nil
+        it "returns nil when the array contains a string" do
+          subject.parse(version_string, ["rubygems"]).should be_nil
         end
 
-        it 'returns nil when the array contains a symbol' do
+        it "returns nil when the array contains a symbol" do
           subject.parse(version_string, [:rubygems]).should be_nil
         end
       end
 
-      context 'when the format is in the list' do
-        let(:version_string) { '10.16.2-rc.2-49-g21353f0' }
+      context "when the format is in the list" do
+        let(:version_string) { "10.16.2-rc.2-49-g21353f0" }
         let(:expected_format) { Mixlib::Versioning::Format::GitDescribe }
-        it 'returns nil when the array contains a Mixlib::Versioning::Format' do
+        it "returns nil when the array contains a Mixlib::Versioning::Format" do
           subject.parse(version_string, [expected_format]).should be_a(expected_format)
         end
 
-        it 'returns nil when the array contains a string' do
-          subject.parse(version_string, ['git_describe']).should be_a(expected_format)
+        it "returns nil when the array contains a string" do
+          subject.parse(version_string, ["git_describe"]).should be_a(expected_format)
         end
 
-        it 'returns nil when the array contains a symbol' do
+        it "returns nil when the array contains a symbol" do
           subject.parse(version_string, [:git_describe]).should be_a(expected_format)
         end
       end
     end
   end # describe .parse
 
-  describe '.find_target_version' do
+  describe ".find_target_version" do
     let(:all_versions) do
-      %w(
+      %w{
         11.0.0-beta.1
         11.0.0-rc.1
         11.0.0
@@ -172,7 +172,7 @@ describe Mixlib::Versioning do
         11.0.2-alpha.0
         11.0.2-alpha.0+2013041116332
         11.0.2
-      )
+      }
     end
     let(:filter_version) { nil }
     let(:use_prerelease_versions) { false }
@@ -182,99 +182,99 @@ describe Mixlib::Versioning do
         all_versions,
         filter_version,
         use_prerelease_versions,
-        use_build_versions,
+        use_build_versions
       )
     end
 
     {
       nil => {
-        releases_only: '11.0.2',
-        prerelease_versions: '11.0.2-alpha.0',
-        build_versions: '11.0.1+2013031116332',
-        prerelease_and_build_versions: '11.0.2-alpha.0+2013041116332',
+        releases_only: "11.0.2",
+        prerelease_versions: "11.0.2-alpha.0",
+        build_versions: "11.0.1+2013031116332",
+        prerelease_and_build_versions: "11.0.2-alpha.0+2013041116332",
       },
-      '11.0.0' => {
-        releases_only: '11.0.0',
-        prerelease_versions: '11.0.0-rc.1',
+      "11.0.0" => {
+        releases_only: "11.0.0",
+        prerelease_versions: "11.0.0-rc.1",
         build_versions: nil,
         prerelease_and_build_versions: nil,
       },
-      '11.0.2' => {
-        releases_only: '11.0.2',
-        prerelease_versions: '11.0.2-alpha.0',
+      "11.0.2" => {
+        releases_only: "11.0.2",
+        prerelease_versions: "11.0.2-alpha.0",
         build_versions: nil,
-        prerelease_and_build_versions: '11.0.2-alpha.0+2013041116332',
+        prerelease_and_build_versions: "11.0.2-alpha.0+2013041116332",
       },
-      '11.0.2' => {
-        releases_only: '11.0.2',
-        prerelease_versions: '11.0.2-alpha.0',
+      "11.0.2" => {
+        releases_only: "11.0.2",
+        prerelease_versions: "11.0.2-alpha.0",
         build_versions: nil,
-        prerelease_and_build_versions: '11.0.2-alpha.0+2013041116332',
+        prerelease_and_build_versions: "11.0.2-alpha.0+2013041116332",
       },
-      '11.0.2-alpha.0' => {
-        releases_only: '11.0.2-alpha.0',
-        prerelease_versions: '11.0.2-alpha.0',
-        build_versions: '11.0.2-alpha.0+2013041116332',
-        prerelease_and_build_versions: '11.0.2-alpha.0+2013041116332',
+      "11.0.2-alpha.0" => {
+        releases_only: "11.0.2-alpha.0",
+        prerelease_versions: "11.0.2-alpha.0",
+        build_versions: "11.0.2-alpha.0+2013041116332",
+        prerelease_and_build_versions: "11.0.2-alpha.0+2013041116332",
       },
     }.each_pair do |filter_version, options|
       context "filter version of: #{filter_version}" do
         let(:filter_version) { filter_version }
         let(:expected_version) { options[:releases_only] }
 
-        it 'finds the most recent release version' do
+        it "finds the most recent release version" do
           subject_find.should eq Mixlib::Versioning.parse(expected_version)
         end
 
-        context 'include pre-release versions' do
+        context "include pre-release versions" do
           let(:use_prerelease_versions) { true }
           let(:expected_version) { options[:prerelease_versions] }
 
-          it 'finds the most recent pre-release version' do
+          it "finds the most recent pre-release version" do
             subject_find.should eq Mixlib::Versioning.parse(expected_version)
           end # it
         end # context
 
-        context 'include build versions' do
+        context "include build versions" do
           let(:use_build_versions) { true }
           let(:expected_version) { options[:build_versions] }
 
-          it 'finds the most recent build version' do
+          it "finds the most recent build version" do
             subject_find.should eq Mixlib::Versioning.parse(expected_version)
           end # it
         end # context
 
-        context 'include pre-release and build versions' do
+        context "include pre-release and build versions" do
           let(:use_prerelease_versions) { true }
           let(:use_build_versions) { true }
           let(:expected_version) { options[:prerelease_and_build_versions] }
 
-          it 'finds the most recent pre-release build version' do
+          it "finds the most recent pre-release build version" do
             subject_find.should eq Mixlib::Versioning.parse(expected_version)
           end # it
         end # context
       end # context
     end # each_pair
 
-    describe 'all_versions argument is a mix of String and Mixlib::Versioning::Format instances' do
+    describe "all_versions argument is a mix of String and Mixlib::Versioning::Format instances" do
       let(:all_versions) do
         [
-          '11.0.0-beta.1',
-          '11.0.0-rc.1',
-          Mixlib::Versioning.parse('11.0.0'),
+          "11.0.0-beta.1",
+          "11.0.0-rc.1",
+          Mixlib::Versioning.parse("11.0.0"),
         ]
       end
 
-      it 'correctly parses the array' do
-        subject_find.should eq Mixlib::Versioning.parse('11.0.0')
+      it "correctly parses the array" do
+        subject_find.should eq Mixlib::Versioning.parse("11.0.0")
       end
     end # describe
 
-    describe 'filter_version argument is an instance of Mixlib::Versioning::Format' do
-      let(:filter_version) { Mixlib::Versioning::Format::SemVer.new('11.0.0') }
+    describe "filter_version argument is an instance of Mixlib::Versioning::Format" do
+      let(:filter_version) { Mixlib::Versioning::Format::SemVer.new("11.0.0") }
 
-      it 'finds the correct version' do
-        subject_find.should eq Mixlib::Versioning.parse('11.0.0')
+      it "finds the correct version" do
+        subject_find.should eq Mixlib::Versioning.parse("11.0.0")
       end
     end
   end # describe

--- a/spec/mixlib/versioning/versioning_spec.rb
+++ b/spec/mixlib/versioning/versioning_spec.rb
@@ -205,7 +205,7 @@ describe Mixlib::Versioning do
         build_versions: nil,
         prerelease_and_build_versions: "11.0.2-alpha.0+2013041116332",
       },
-      "11.0.2" => {
+      "11.0.2" => { # rubocop: disable Lint/DuplicatedKey
         releases_only: "11.0.2",
         prerelease_versions: "11.0.2-alpha.0",
         build_versions: nil,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,19 +16,19 @@
 # limitations under the License.
 #
 
-require 'mixlib/versioning'
+require "mixlib/versioning"
 
 # load all shared examples and shared contexts
-Dir[File.expand_path('../support/**/*.rb', __FILE__)].each do |file|
+Dir[File.expand_path("../support/**/*.rb", __FILE__)].each do |file|
   require(file)
 end
 
 RSpec.configure do |config|
   # a little syntactic sugar
-  config.alias_it_should_behave_like_to :it_has_behavior, 'has behavior:'
+  config.alias_it_should_behave_like_to :it_has_behavior, "has behavior:"
 
   # Use color in STDOUT
-  config.color_enabled = true
+  config.color = true
 
   # Use color not only in STDOUT but also in pagers and files
   config.tty = true

--- a/spec/support/shared_examples/basic_semver.rb
+++ b/spec/support/shared_examples/basic_semver.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-shared_examples 'Basic SemVer' do
-  it_has_behavior 'parses valid version strings', {
-    '1.2.3' => {
+shared_examples "Basic SemVer" do
+  it_has_behavior "parses valid version strings", {
+    "1.2.3" => {
       major: 1,
       minor: 2,
       patch: 3,
@@ -32,9 +32,9 @@ shared_examples 'Basic SemVer' do
     },
   }
 
-  it_has_behavior 'rejects invalid version strings', {
-    'a.1.1' => 'non-numeric MAJOR',
-    '1.a.1' => 'non-numeric MINOR',
-    '1.1.a' => 'non-numeric PATCH',
+  it_has_behavior "rejects invalid version strings", {
+    "a.1.1" => "non-numeric MAJOR",
+    "1.a.1" => "non-numeric MINOR",
+    "1.1.a" => "non-numeric PATCH",
   }
 end

--- a/spec/support/shared_examples/behaviors/comparable.rb
+++ b/spec/support/shared_examples/behaviors/comparable.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-shared_examples 'comparable' do |version_matrix|
-  describe '#<' do
+shared_examples "comparable" do |version_matrix|
+  describe "#<" do
     version_matrix.each_slice(2) do |a, b|
       it "confirms that #{a} is less-than #{b}" do
         expect(described_class.new(a) < b).to be true
@@ -26,7 +26,7 @@ shared_examples 'comparable' do |version_matrix|
     end
   end
 
-  describe '#<=' do
+  describe "#<=" do
     version_matrix.each_slice(2) do |a, b|
       it "confirms that #{a} less-than or equal to #{b}" do
         expect(described_class.new(a) <= b).to be true
@@ -37,7 +37,7 @@ shared_examples 'comparable' do |version_matrix|
     end
   end
 
-  describe '#==' do
+  describe "#==" do
     version_matrix.each do |v|
       it "confirms that #{v} is equal to #{v}" do
         expect(described_class.new(v) == v).to be true
@@ -47,7 +47,7 @@ shared_examples 'comparable' do |version_matrix|
     end
   end
 
-  describe '#>' do
+  describe "#>" do
     version_matrix.reverse.each_slice(2) do |a, b|
       it "confirms that #{a} is greather-than #{b}" do
         expect(described_class.new(a) > b).to be true
@@ -56,7 +56,7 @@ shared_examples 'comparable' do |version_matrix|
     end
   end
 
-  describe '#>=' do
+  describe "#>=" do
     version_matrix.reverse.each_slice(2) do |a, b|
       it "confirms that #{a} greater-than or equal to #{b}" do
         expect(described_class.new(a) >= b).to be true
@@ -67,10 +67,10 @@ shared_examples 'comparable' do |version_matrix|
     end
   end
 
-  describe '#between?' do
+  describe "#between?" do
     let(:versions) { version_matrix.map { |v| described_class.new(v) }.sort }
 
-    it 'comfirms that a version is between the oldest and latest release' do
+    it "comfirms that a version is between the oldest and latest release" do
       min, max = versions.minmax.map(&:to_s)
       middle = versions[versions.size / 2].to_s
       expect(described_class.new(middle).between?(min, max)).to be true

--- a/spec/support/shared_examples/behaviors/filterable.rb
+++ b/spec/support/shared_examples/behaviors/filterable.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-shared_examples 'filterable' do
+shared_examples "filterable" do
   let(:unsorted_versions) do
     unsorted_version_strings.map { |v| described_class.new(v) }
   end
@@ -28,26 +28,26 @@ shared_examples 'filterable' do
   let(:release_build_versions) { [] }
   let(:prerelease_build_versions) { [] }
 
-  it 'filters by release versions only' do
+  it "filters by release versions only" do
     unsorted_versions.select(&:release?).should eq(release_versions.map { |v| described_class.new(v) })
   end # it
 
-  it 'filters by pre-release versions only' do
+  it "filters by pre-release versions only" do
     filtered = unsorted_versions.select(&:prerelease?)
     filtered.should eq(prerelease_versions.map { |v| described_class.new(v) })
   end # it
 
-  it 'filters by build versions only' do
+  it "filters by build versions only" do
     filtered = unsorted_versions.select(&:build?)
     filtered.should eq(build_versions.map { |v| described_class.new(v) })
   end # it
 
-  it 'filters by release build versions only' do
+  it "filters by release build versions only" do
     filtered = unsorted_versions.select(&:release_build?)
     filtered.should eq(release_build_versions.map { |v| described_class.new(v) })
   end # it
 
-  it 'filters by pre-release build versions only' do
+  it "filters by pre-release build versions only" do
     filtered = unsorted_versions.select(&:prerelease_build?)
     filtered.should eq(prerelease_build_versions.map { |v| described_class.new(v) })
   end # it

--- a/spec/support/shared_examples/behaviors/parses_valid_version_strings.rb
+++ b/spec/support/shared_examples/behaviors/parses_valid_version_strings.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-shared_examples 'parses valid version strings' do |valid_examples|
+shared_examples "parses valid version strings" do |valid_examples|
   valid_examples.each do |version, options|
     context version do
       let(:version_string) { version }

--- a/spec/support/shared_examples/behaviors/rejects_invalid_version_strings.rb
+++ b/spec/support/shared_examples/behaviors/rejects_invalid_version_strings.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-shared_examples 'rejects invalid version strings' do |invalid_examples|
+shared_examples "rejects invalid version strings" do |invalid_examples|
   invalid_examples.each_pair do |version, reason|
     context version do
       let(:version_string) { version }

--- a/spec/support/shared_examples/behaviors/serializable.rb
+++ b/spec/support/shared_examples/behaviors/serializable.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-shared_examples 'serializable' do |version_strings|
-  describe '#to_s' do
+shared_examples "serializable" do |version_strings|
+  describe "#to_s" do
     version_strings.each do |v|
       it "reconstructs the initial input for #{v}" do
         described_class.new(v).to_s.should == v
@@ -25,7 +25,7 @@ shared_examples 'serializable' do |version_strings|
     end # version_strings
   end # describe
 
-  describe '#to_semver_string' do
+  describe "#to_semver_string" do
     version_strings.each do |v|
       it "generates a semver version string for #{v}" do
         subject = described_class.new(v)
@@ -36,7 +36,7 @@ shared_examples 'serializable' do |version_strings|
     end # version_strings
   end # describe
 
-  describe '#to_rubygems_string' do
+  describe "#to_rubygems_string" do
     version_strings.each do |v|
       it "generates a rubygems version string for #{v}" do
         subject = described_class.new(v)

--- a/spec/support/shared_examples/behaviors/sortable.rb
+++ b/spec/support/shared_examples/behaviors/sortable.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-shared_examples 'sortable' do
+shared_examples "sortable" do
   let(:unsorted_versions) do
     unsorted_version_strings.map { |v| described_class.new(v) }
   end
@@ -25,19 +25,19 @@ shared_examples 'sortable' do
     sorted_version_strings.map { |v| described_class.new(v) }
   end
 
-  it 'responds to <=>' do
+  it "responds to <=>" do
     described_class.should respond_to(:<=>)
   end
 
-  it 'sorts all properly' do
+  it "sorts all properly" do
     unsorted_versions.sort.should eq sorted_versions
   end
 
-  it 'finds the min' do
+  it "finds the min" do
     unsorted_versions.min.should eq described_class.new(min)
   end
 
-  it 'finds the max' do
+  it "finds the max" do
     unsorted_versions.max.should eq described_class.new(max)
   end
 end # shared_examples

--- a/spec/support/shared_examples/semver.rb
+++ b/spec/support/shared_examples/semver.rb
@@ -16,17 +16,17 @@
 # limitations under the License.
 #
 
-require 'mixlib/versioning'
+require "mixlib/versioning"
 
 shared_examples Mixlib::Versioning::Format::SemVer do
-  it_should_behave_like 'Basic SemVer'
+  it_should_behave_like "Basic SemVer"
 
-  it_has_behavior 'parses valid version strings', {
-    '1.0.0-alpha.1' => {
+  it_has_behavior "parses valid version strings", {
+    "1.0.0-alpha.1" => {
       major: 1,
       minor: 0,
       patch: 0,
-      prerelease: 'alpha.1',
+      prerelease: "alpha.1",
       build: nil,
       release?: false,
       prerelease?: true,
@@ -34,24 +34,24 @@ shared_examples Mixlib::Versioning::Format::SemVer do
       release_build?: false,
       prerelease_build?: false,
     },
-    '1.0.0+20130308110833' => {
+    "1.0.0+20130308110833" => {
       major: 1,
       minor: 0,
       patch: 0,
       prerelease: nil,
-      build: '20130308110833',
+      build: "20130308110833",
       release?: false,
       prerelease?: false,
       build?: true,
       release_build?: true,
       prerelease_build?: false,
     },
-    '1.0.0-beta.3+20130308110833' => {
+    "1.0.0-beta.3+20130308110833" => {
       major: 1,
       minor: 0,
       patch: 0,
-      prerelease: 'beta.3',
-      build: '20130308110833',
+      prerelease: "beta.3",
+      build: "20130308110833",
       release?: false,
       prerelease?: false,
       build?: true,
@@ -60,26 +60,26 @@ shared_examples Mixlib::Versioning::Format::SemVer do
     },
   }
 
-  it_has_behavior 'rejects invalid version strings', {
-    '8.8.8.8' => 'too many segments: MAJOR.MINOR.PATCH.EXTRA',
-    '01.1.1' => 'leading zero invalid',
-    '1.01.1' => 'leading zero invalid',
-    '1.1.01' => 'leading zero invalid',
-    '1.0.0-' => 'empty prerelease identifier',
-    '1.0.0-alpha..' => 'empty prerelease identifier',
-    '1.0.0-01.02.03' => 'leading zero invalid',
-    '1.0.0-alpha.01' => 'leading zero invalid',
-    '6.3.1+' => 'empty build identifier',
-    '6.4.8-alpha.1.2.3+build.' => 'empty build identifier',
-    '4.0.000000000002-alpha.1' => 'leading zero invalid',
-    '007.2.3-rc.1+build.16' => 'leading zero invalid',
-    '12.0005.1-alpha.12' => 'leading zero invalid',
-    '12.2.10-beta.00000017' => 'leading zero invalid',
+  it_has_behavior "rejects invalid version strings", {
+    "8.8.8.8" => "too many segments: MAJOR.MINOR.PATCH.EXTRA",
+    "01.1.1" => "leading zero invalid",
+    "1.01.1" => "leading zero invalid",
+    "1.1.01" => "leading zero invalid",
+    "1.0.0-" => "empty prerelease identifier",
+    "1.0.0-alpha.." => "empty prerelease identifier",
+    "1.0.0-01.02.03" => "leading zero invalid",
+    "1.0.0-alpha.01" => "leading zero invalid",
+    "6.3.1+" => "empty build identifier",
+    "6.4.8-alpha.1.2.3+build." => "empty build identifier",
+    "4.0.000000000002-alpha.1" => "leading zero invalid",
+    "007.2.3-rc.1+build.16" => "leading zero invalid",
+    "12.0005.1-alpha.12" => "leading zero invalid",
+    "12.2.10-beta.00000017" => "leading zero invalid",
   }
 
-  describe 'build qualification' do
-    context 'release version' do
-      let(:version_string) { '1.0.0' }
+  describe "build qualification" do
+    context "release version" do
+      let(:version_string) { "1.0.0" }
       its(:release?) { should be_true }
       its(:prerelease?) { should be_false }
       its(:build?) { should be_false }
@@ -87,8 +87,8 @@ shared_examples Mixlib::Versioning::Format::SemVer do
       its(:prerelease_build?) { should be_false }
     end
 
-    context 'pre-release version' do
-      let(:version_string) { '1.0.0-alpha.1' }
+    context "pre-release version" do
+      let(:version_string) { "1.0.0-alpha.1" }
       its(:release?) { should be_false }
       its(:prerelease?) { should be_true }
       its(:build?) { should be_false }
@@ -96,8 +96,8 @@ shared_examples Mixlib::Versioning::Format::SemVer do
       its(:prerelease_build?) { should be_false }
     end
 
-    context 'pre-release build version' do
-      let(:version_string) { '1.0.0-alpha.1+20130308110833' }
+    context "pre-release build version" do
+      let(:version_string) { "1.0.0-alpha.1+20130308110833" }
       its(:release?) { should be_false }
       its(:prerelease?) { should be_false }
       its(:build?) { should be_true }
@@ -105,8 +105,8 @@ shared_examples Mixlib::Versioning::Format::SemVer do
       its(:prerelease_build?) { should be_true }
     end
 
-    context 'release build version' do
-      let(:version_string) { '1.0.0+20130308110833' }
+    context "release build version" do
+      let(:version_string) { "1.0.0+20130308110833" }
       its(:release?) { should be_false }
       its(:prerelease?) { should be_false }
       its(:build?) { should be_true }


### PR DESCRIPTION
Ruby Ruby 2.2+
Switch from rubocop to chefstyle
Cleanup travis config
Add contributing links
Get the travis build green by pinning rspec to < 2.99