### PR TITLE
Use rspec 3.x

### DIFF
--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
 
   # Development dependencies
   spec.add_development_dependency "chefstyle"
-  spec.add_development_dependency "rspec", "< 2.99"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end

--- a/spec/mixlib/versioning/format_spec.rb
+++ b/spec/mixlib/versioning/format_spec.rb
@@ -39,7 +39,7 @@ describe Mixlib::Versioning::Format do
       context 'format_type is a: #{format_type.class}' do
         let(:format_type) { format_type }
         it "returns the correct format class" do
-          subject.for(format_type).should eq Mixlib::Versioning::Format::Rubygems
+          expect(subject.for(format_type)).to eq Mixlib::Versioning::Format::Rubygems
         end # it
       end # context
     end # each

--- a/spec/mixlib/versioning/versioning_spec.rb
+++ b/spec/mixlib/versioning/versioning_spec.rb
@@ -59,7 +59,7 @@ describe Mixlib::Versioning do
             context "format type as a: #{format_type.class}" do
               it "parses version string as: #{options[:expected_format]}" do
                 result = subject.parse(version_string, format_type)
-                result.should be_a(expected_format)
+                expect(result).to be_a(expected_format)
               end # it
             end # context
           end # each
@@ -106,7 +106,7 @@ describe Mixlib::Versioning do
         context version_string do
           let(:version_string) { version_string }
           it "parses version string as: #{expected_format}" do
-            subject.parse(version_string).should be_a(expected_format)
+            expect(subject.parse(version_string)).to be_a(expected_format)
           end # it
         end # context
       end # each_pair
@@ -114,7 +114,7 @@ describe Mixlib::Versioning do
       describe "version_string cannot be parsed" do
         let(:version_string) { "A.B.C" }
         it "returns nil" do
-          subject.parse(version_string).should be_nil
+          expect(subject.parse(version_string)).to be_nil
         end
       end
     end # describe "parsing with automatic format detection"
@@ -123,7 +123,7 @@ describe Mixlib::Versioning do
       it "returns the same object" do
         v = Mixlib::Versioning.parse(version_string)
         result = subject.parse(v)
-        v.should be result
+        expect(v).to be result
       end
     end
 
@@ -131,15 +131,15 @@ describe Mixlib::Versioning do
       context "when the format is not in the list" do
         let(:version_string) { "10.16.2-rc.2-49-g21353f0" }
         it "returns nil when the array contains a Mixlib::Versioning::Format" do
-          subject.parse(version_string, [Mixlib::Versioning::Format::Rubygems]).should be_nil
+          expect(subject.parse(version_string, [Mixlib::Versioning::Format::Rubygems])).to be_nil
         end
 
         it "returns nil when the array contains a string" do
-          subject.parse(version_string, ["rubygems"]).should be_nil
+          expect(subject.parse(version_string, ["rubygems"])).to be_nil
         end
 
         it "returns nil when the array contains a symbol" do
-          subject.parse(version_string, [:rubygems]).should be_nil
+          expect(subject.parse(version_string, [:rubygems])).to be_nil
         end
       end
 
@@ -147,15 +147,15 @@ describe Mixlib::Versioning do
         let(:version_string) { "10.16.2-rc.2-49-g21353f0" }
         let(:expected_format) { Mixlib::Versioning::Format::GitDescribe }
         it "returns nil when the array contains a Mixlib::Versioning::Format" do
-          subject.parse(version_string, [expected_format]).should be_a(expected_format)
+          expect(subject.parse(version_string, [expected_format])).to be_a(expected_format)
         end
 
         it "returns nil when the array contains a string" do
-          subject.parse(version_string, ["git_describe"]).should be_a(expected_format)
+          expect(subject.parse(version_string, ["git_describe"])).to be_a(expected_format)
         end
 
         it "returns nil when the array contains a symbol" do
-          subject.parse(version_string, [:git_describe]).should be_a(expected_format)
+          expect(subject.parse(version_string, [:git_describe])).to be_a(expected_format)
         end
       end
     end
@@ -223,7 +223,7 @@ describe Mixlib::Versioning do
         let(:expected_version) { options[:releases_only] }
 
         it "finds the most recent release version" do
-          subject_find.should eq Mixlib::Versioning.parse(expected_version)
+          expect(subject_find).to eq Mixlib::Versioning.parse(expected_version)
         end
 
         context "include pre-release versions" do
@@ -231,7 +231,7 @@ describe Mixlib::Versioning do
           let(:expected_version) { options[:prerelease_versions] }
 
           it "finds the most recent pre-release version" do
-            subject_find.should eq Mixlib::Versioning.parse(expected_version)
+            expect(subject_find).to eq Mixlib::Versioning.parse(expected_version)
           end # it
         end # context
 
@@ -240,7 +240,7 @@ describe Mixlib::Versioning do
           let(:expected_version) { options[:build_versions] }
 
           it "finds the most recent build version" do
-            subject_find.should eq Mixlib::Versioning.parse(expected_version)
+            expect(subject_find).to eq Mixlib::Versioning.parse(expected_version)
           end # it
         end # context
 
@@ -250,7 +250,7 @@ describe Mixlib::Versioning do
           let(:expected_version) { options[:prerelease_and_build_versions] }
 
           it "finds the most recent pre-release build version" do
-            subject_find.should eq Mixlib::Versioning.parse(expected_version)
+            expect(subject_find).to eq Mixlib::Versioning.parse(expected_version)
           end # it
         end # context
       end # context
@@ -266,7 +266,7 @@ describe Mixlib::Versioning do
       end
 
       it "correctly parses the array" do
-        subject_find.should eq Mixlib::Versioning.parse("11.0.0")
+        expect(subject_find).to eq Mixlib::Versioning.parse("11.0.0")
       end
     end # describe
 
@@ -274,7 +274,7 @@ describe Mixlib::Versioning do
       let(:filter_version) { Mixlib::Versioning::Format::SemVer.new("11.0.0") }
 
       it "finds the correct version" do
-        subject_find.should eq Mixlib::Versioning.parse("11.0.0")
+        expect(subject_find).to eq Mixlib::Versioning.parse("11.0.0")
       end
     end
   end # describe

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 #
 
 require "mixlib/versioning"
+require "rspec/its"
 
 # load all shared examples and shared contexts
 Dir[File.expand_path("../support/**/*.rb", __FILE__)].each do |file|
@@ -36,8 +37,6 @@ RSpec.configure do |config|
   # run the examples in random order
   config.order = :rand
 
-  # specify metadata with symobls only (ie no '=> true' required)
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 end

--- a/spec/support/shared_examples/behaviors/filterable.rb
+++ b/spec/support/shared_examples/behaviors/filterable.rb
@@ -29,26 +29,26 @@ shared_examples "filterable" do
   let(:prerelease_build_versions) { [] }
 
   it "filters by release versions only" do
-    unsorted_versions.select(&:release?).should eq(release_versions.map { |v| described_class.new(v) })
+    expect(unsorted_versions.select(&:release?)).to eq(release_versions.map { |v| described_class.new(v) })
   end # it
 
   it "filters by pre-release versions only" do
     filtered = unsorted_versions.select(&:prerelease?)
-    filtered.should eq(prerelease_versions.map { |v| described_class.new(v) })
+    expect(filtered).to eq(prerelease_versions.map { |v| described_class.new(v) })
   end # it
 
   it "filters by build versions only" do
     filtered = unsorted_versions.select(&:build?)
-    filtered.should eq(build_versions.map { |v| described_class.new(v) })
+    expect(filtered).to eq(build_versions.map { |v| described_class.new(v) })
   end # it
 
   it "filters by release build versions only" do
     filtered = unsorted_versions.select(&:release_build?)
-    filtered.should eq(release_build_versions.map { |v| described_class.new(v) })
+    expect(filtered).to eq(release_build_versions.map { |v| described_class.new(v) })
   end # it
 
   it "filters by pre-release build versions only" do
     filtered = unsorted_versions.select(&:prerelease_build?)
-    filtered.should eq(prerelease_build_versions.map { |v| described_class.new(v) })
+    expect(filtered).to eq(prerelease_build_versions.map { |v| described_class.new(v) })
   end # it
 end # shared_examples

--- a/spec/support/shared_examples/behaviors/serializable.rb
+++ b/spec/support/shared_examples/behaviors/serializable.rb
@@ -20,7 +20,7 @@ shared_examples "serializable" do |version_strings|
   describe "#to_s" do
     version_strings.each do |v|
       it "reconstructs the initial input for #{v}" do
-        described_class.new(v).to_s.should == v
+        expect(described_class.new(v).to_s).to eq(v)
       end # it
     end # version_strings
   end # describe
@@ -31,7 +31,7 @@ shared_examples "serializable" do |version_strings|
         subject = described_class.new(v)
         string = subject.to_semver_string
         semver = Mixlib::Versioning::Format::SemVer.new(string)
-        string.should eq semver.to_s
+        expect(string).to eq semver.to_s
       end # it
     end # version_strings
   end # describe
@@ -42,7 +42,7 @@ shared_examples "serializable" do |version_strings|
         subject = described_class.new(v)
         string = subject.to_rubygems_string
         rubygems = Mixlib::Versioning::Format::Rubygems.new(string)
-        string.should eq rubygems.to_s
+        expect(string).to eq rubygems.to_s
       end # it
     end # version_strings
   end # describe

--- a/spec/support/shared_examples/behaviors/sortable.rb
+++ b/spec/support/shared_examples/behaviors/sortable.rb
@@ -26,18 +26,18 @@ shared_examples "sortable" do
   end
 
   it "responds to <=>" do
-    described_class.should respond_to(:<=>)
+    expect(described_class).to respond_to(:<=>)
   end
 
   it "sorts all properly" do
-    unsorted_versions.sort.should eq sorted_versions
+    expect(unsorted_versions.sort).to eq sorted_versions
   end
 
   it "finds the min" do
-    unsorted_versions.min.should eq described_class.new(min)
+    expect(unsorted_versions.min).to eq described_class.new(min)
   end
 
   it "finds the max" do
-    unsorted_versions.max.should eq described_class.new(max)
+    expect(unsorted_versions.max).to eq described_class.new(max)
   end
 end # shared_examples

--- a/spec/support/shared_examples/semver.rb
+++ b/spec/support/shared_examples/semver.rb
@@ -80,38 +80,38 @@ shared_examples Mixlib::Versioning::Format::SemVer do
   describe "build qualification" do
     context "release version" do
       let(:version_string) { "1.0.0" }
-      its(:release?) { should be_true }
-      its(:prerelease?) { should be_false }
-      its(:build?) { should be_false }
-      its(:release_build?) { should be_false }
-      its(:prerelease_build?) { should be_false }
+      its(:release?) { should be_truthy }
+      its(:prerelease?) { should be_falsey }
+      its(:build?) { should be_falsey }
+      its(:release_build?) { should be_falsey }
+      its(:prerelease_build?) { should be_falsey }
     end
 
     context "pre-release version" do
       let(:version_string) { "1.0.0-alpha.1" }
-      its(:release?) { should be_false }
-      its(:prerelease?) { should be_true }
-      its(:build?) { should be_false }
-      its(:release_build?) { should be_false }
-      its(:prerelease_build?) { should be_false }
+      its(:release?) { should be_falsey }
+      its(:prerelease?) { should be_truthy }
+      its(:build?) { should be_falsey }
+      its(:release_build?) { should be_falsey }
+      its(:prerelease_build?) { should be_falsey }
     end
 
     context "pre-release build version" do
       let(:version_string) { "1.0.0-alpha.1+20130308110833" }
-      its(:release?) { should be_false }
-      its(:prerelease?) { should be_false }
-      its(:build?) { should be_true }
-      its(:release_build?) { should be_false }
-      its(:prerelease_build?) { should be_true }
+      its(:release?) { should be_falsey }
+      its(:prerelease?) { should be_falsey }
+      its(:build?) { should be_truthy }
+      its(:release_build?) { should be_falsey }
+      its(:prerelease_build?) { should be_truthy }
     end
 
     context "release build version" do
       let(:version_string) { "1.0.0+20130308110833" }
-      its(:release?) { should be_false }
-      its(:prerelease?) { should be_false }
-      its(:build?) { should be_true }
-      its(:release_build?) { should be_true }
-      its(:prerelease_build?) { should be_false }
+      its(:release?) { should be_falsey }
+      its(:prerelease?) { should be_falsey }
+      its(:build?) { should be_truthy }
+      its(:release_build?) { should be_truthy }
+      its(:prerelease_build?) { should be_falsey }
     end
   end
 end


### PR DESCRIPTION
Use rspec-its to avoid converting all the specs since transpec conversion failed

Signed-off-by: Tim Smith <tsmith@chef.io>