### PR TITLE
Partial version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ Examples of valid Git Describe version strings:
 11.0.0-alpha.1-1-gcea071e
 ```
 
+
+## SemVer Partial
+
+
+```text
+MAJOR
+MAJOR.MINOR
+```
+
+Examples of valid SemVer Partial version strings:
+
+```text
+1
+0.1
+1.0
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -342,7 +359,7 @@ For information on contributing to this project see <https://github.com/chef/che
 |:---------------------|:-----------------------------------------|
 | **Author:**          | Seth Chisamore (schisamo@chef.io)
 | **Author:**          | Christopher Maier (cm@chef.io)
-| **Copyright:**       | Copyright (c) 2013-2016 Chef Software, Inc.
+| **Copyright:**       | Copyright (c) 2013-2017 Chef Software, Inc.
 | **License:**         | Apache License, Version 2.0
 
 ```text

--- a/lib/mixlib/versioning.rb
+++ b/lib/mixlib/versioning.rb
@@ -2,6 +2,7 @@
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Author:: Christopher Maier (<cm@chef.io>)
 # Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +30,7 @@ module Mixlib
       Mixlib::Versioning::Format::OpscodeSemVer,
       Mixlib::Versioning::Format::SemVer,
       Mixlib::Versioning::Format::Rubygems,
+      Mixlib::Versioning::Format::PartialSemVer,
     ].freeze
 
     # Create a new {Format} instance given a version string to parse, and an
@@ -55,7 +57,7 @@ module Mixlib
     #
     def self.parse(version_string, format = nil)
       if version_string.is_a?(Mixlib::Versioning::Format)
-        return version_string
+        version_string
       else
         formats = if format
                     [format].flatten.map { |f| Mixlib::Versioning::Format.for(f) }
@@ -71,7 +73,7 @@ module Mixlib
             next
           end
         end
-        return parsed_version
+        parsed_version
       end
     end
 

--- a/lib/mixlib/versioning/format.rb
+++ b/lib/mixlib/versioning/format.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +21,7 @@ require "mixlib/versioning/format/git_describe"
 require "mixlib/versioning/format/opscode_semver"
 require "mixlib/versioning/format/rubygems"
 require "mixlib/versioning/format/semver"
+require "mixlib/versioning/format/partial_semver"
 
 module Mixlib
   class Versioning
@@ -30,15 +32,15 @@ module Mixlib
     # @!attribute [r] minor
     #   @return [Integer] minor identifier
     # @!attribute [r] patch
-    #   @return [Integer] patch identifier
+    #   @return [Integer, nil] patch identifier
     # @!attribute [r] prerelease
-    #   @return [String] pre-release identifier
+    #   @return [String, nil] pre-release identifier
     # @!attribute [r] build
-    #   @return [String] build identifier
+    #   @return [String, nil] build identifier
     # @!attribute [r] iteration
-    #   @return [String] build interation
+    #   @return [String, nil] build interation
     # @!attribute [r] input
-    #   @return [String] original input version string that was parsed
+    #   @return [String, nil] original input version string that was parsed
     class Format
       include Comparable
 
@@ -68,6 +70,7 @@ module Mixlib
           when "opscode_semver" then Mixlib::Versioning::Format::OpscodeSemVer
           when "git_describe" then Mixlib::Versioning::Format::GitDescribe
           when "rubygems" then Mixlib::Versioning::Format::Rubygems
+          when "partial_semver" then Mixlib::Versioning::Format::PartialSemVer
           else
             msg = "'#{format_type}' is not a supported Mixlib::Versioning format"
             raise Mixlib::Versioning::UnknownFormatError, msg
@@ -167,7 +170,7 @@ module Mixlib
       #   {Format} instance
       # @todo create a proper serialization abstraction
       def to_semver_string
-        s = [@major, @minor, @patch].join(".")
+        s = [@major, @minor, @patch].map(&:to_i).join(".")
         s += "-#{@prerelease}" if @prerelease
         s += "+#{@build}" if @build
         s
@@ -184,7 +187,7 @@ module Mixlib
       #   {Format} instance
       # @todo create a proper serialization abstraction
       def to_rubygems_string
-        s = [@major, @minor, @patch].join(".")
+        s = [@major, @minor, @patch].map(&:to_i).join(".")
         s += ".#{@prerelease}" if @prerelease
         s
       end

--- a/lib/mixlib/versioning/format/partial_semver.rb
+++ b/lib/mixlib/versioning/format/partial_semver.rb
@@ -1,0 +1,62 @@
+#
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Christopher Maier (<cm@chef.io>)
+# Author:: Ryan Hass (<rhass@chef.io>)
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Mixlib
+  class Versioning
+    class Format
+      # Handles partial version strings.
+      # -----------------
+      # ```text
+      # MAJOR
+      # MAJOR.MINOR
+      # ```
+      #
+      # EXAMPLES
+      # --------
+      # ```text
+      # 11
+      # 11.0
+      # ```
+      #
+      # @author Seth Chisamore (<schisamo@chef.io>)
+      # @author Christopher Maier (<cm@chef.io>)
+      # @author Ryan Hass (<rhass@chef.io>)
+      class PartialSemVer < Format
+        #  http://rubular.com/r/NmRSN8vCie
+        PARTIAL_REGEX = /^(\d+)\.?(?:(\d*))$/
+        # @see Format#parse
+        def parse(version_string)
+          match = version_string.match(PARTIAL_REGEX) rescue nil
+
+          unless match
+            raise Mixlib::Versioning::ParseError, "'#{version_string}' is not a valid #{self.class} version string!"
+          end
+
+          @major, @minor = match[1..2]
+          @major, @minor, @patch = [@major, @minor, @patch].map(&:to_i)
+
+          # Partial versions do not contain these values, so we just set them to nil.
+          @prerelease = nil
+          @build      = nil
+        end
+      end # class Partial
+    end # class Format
+  end # module Versioning
+end # module Mixlib

--- a/lib/mixlib/versioning/format/rubygems.rb
+++ b/lib/mixlib/versioning/format/rubygems.rb
@@ -53,9 +53,15 @@ module Mixlib
           end
 
           @major, @minor, @patch, @prerelease, @iteration = match[1..5]
-          @major, @minor, @patch, @iteration = [@major, @minor, @patch, @iteration].map(&:to_i)
+          @major, @minor, @patch = [@major, @minor, @patch].map(&:to_i)
 
-          # Do not convert @build to an integer; SemVer sorting logic will handle the conversion
+          # Do not convert @prerelease or @iteration to an integer;
+          # sorting logic will handle the conversion.
+          @iteration = if @iteration.nil? || @iteration.empty?
+                         nil
+                       else
+                         @iteration.to_i
+                       end
           @prerelease = nil if @prerelease.nil? || @prerelease.empty?
         end
       end # class Rubygems

--- a/spec/mixlib/versioning/format/partial_semver_spec.rb
+++ b/spec/mixlib/versioning/format/partial_semver_spec.rb
@@ -1,0 +1,121 @@
+#
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Ryan Hass (<rhass@chef.io>)
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Mixlib::Versioning::Format::PartialSemVer do
+  subject { described_class.new(version_string) }
+
+  it_has_behavior "serializable", [
+    "1",
+    "12",
+    "1.2",
+    "1.23",
+    "12.3",
+    "12.34",
+  ]
+
+  it_has_behavior "sortable" do
+    let(:unsorted_version_strings) do
+      %w{
+        2
+        1.1
+        1
+        1.0
+        2.0
+        1.2
+      }
+    end
+    let(:sorted_version_strings) do
+      %w{
+        1
+        1.0
+        1.1
+        1.2
+        2
+        2.0
+      }
+    end
+    let(:min) { "1" }
+    let(:max) { "2.0" }
+  end # it_has_behavior
+
+  it_has_behavior "filterable" do
+    let(:unsorted_version_strings) do
+      %w{
+        2
+        1.1
+        1
+        1.0
+        2.0
+        1.2
+        12.0
+        12
+      }
+    end
+    let(:release_versions) do
+      %w{
+        2.0
+        1.1
+        1.0
+        1.0
+        2.0
+        1.2
+        12.0
+        12.0
+      }
+    end
+  end # it_has_behavior
+
+  it_has_behavior "comparable", [
+    "1", "2",
+    "1", "1.1",
+    "1.1", "2",
+    "1.1", "1.2"
+  ]
+
+  it_has_behavior "comparable_types", [
+    "0.1", { value: "1.0.0.pre.1", class: Mixlib::Versioning::Format::Rubygems },
+    "0.1", { value: "1.0.0-rc.1", class: Mixlib::Versioning::Format::OpscodeSemVer },
+    "1", { value: "1.0.1", class: Mixlib::Versioning::Format::Rubygems },
+    "1", { value: "1.0.1", class: Mixlib::Versioning::Format::SemVer },
+    "1", { value: "1.0.1", class: Mixlib::Versioning::Format::OpscodeSemVer },
+    "1", { value: "1.0.0-1-gdeadbee-1", class: Mixlib::Versioning::Format::GitDescribe },
+    "1", { value: "2.0.0", class: Mixlib::Versioning::Format::Rubygems },
+    "1", { value: "2.0.0", class: Mixlib::Versioning::Format::SemVer },
+    "1", { value: "2.0.0-rc.1", class: Mixlib::Versioning::Format::OpscodeSemVer },
+    "1", { value: "2.0.0-1-gdeadbee-1", class: Mixlib::Versioning::Format::GitDescribe },
+    "1", { value: "1.1.0", class: Mixlib::Versioning::Format::Rubygems },
+    "1", { value: "1.1.0", class: Mixlib::Versioning::Format::SemVer },
+    "1", { value: "1.1.0", class: Mixlib::Versioning::Format::OpscodeSemVer },
+    "1", { value: "1.1.0-1-gdeadbee-1", class: Mixlib::Versioning::Format::GitDescribe },
+    "1.1", { value: "1.1.1", class: Mixlib::Versioning::Format::Rubygems },
+    "1.1", { value: "1.1.1", class: Mixlib::Versioning::Format::SemVer },
+    "1.1", { value: "1.1.1", class: Mixlib::Versioning::Format::OpscodeSemVer },
+    "1.1", { value: "1.1.1-1-gdeadbee-1", class: Mixlib::Versioning::Format::GitDescribe },
+    "1.1", { value: "2.0.0", class: Mixlib::Versioning::Format::Rubygems },
+    "1.1", { value: "2.0.0", class: Mixlib::Versioning::Format::SemVer },
+    "1.1", { value: "2.0.0", class: Mixlib::Versioning::Format::OpscodeSemVer },
+    "1.1", { value: "2.0.0-1-gdeadbee-1", class: Mixlib::Versioning::Format::GitDescribe },
+    "1.1", { value: "1.2.0", class: Mixlib::Versioning::Format::Rubygems },
+    "1.1", { value: "1.2.0", class: Mixlib::Versioning::Format::SemVer },
+    "1.1", { value: "1.2.0", class: Mixlib::Versioning::Format::OpscodeSemVer },
+    "1.1", { value: "1.2.0-1-gdeadbee-1", class: Mixlib::Versioning::Format::GitDescribe }
+  ]
+end # describe

--- a/spec/mixlib/versioning/format/rubygems_spec.rb
+++ b/spec/mixlib/versioning/format/rubygems_spec.rb
@@ -35,7 +35,7 @@ describe Mixlib::Versioning::Format::Rubygems do
       build?: false,
       release_build?: false,
       prerelease_build?: false,
-      iteration: 0,
+      iteration: nil,
     },
     "10.1.1.alpha.1" => {
       major: 10,
@@ -48,7 +48,7 @@ describe Mixlib::Versioning::Format::Rubygems do
       build?: false,
       release_build?: false,
       prerelease_build?: false,
-      iteration: 0,
+      iteration: nil,
     },
     "11.0.8.rc.3" => {
       major: 11,
@@ -61,7 +61,7 @@ describe Mixlib::Versioning::Format::Rubygems do
       build?: false,
       release_build?: false,
       prerelease_build?: false,
-      iteration: 0,
+      iteration: nil,
     },
     "11.0.8-33" => {
       major: 11,

--- a/spec/mixlib/versioning/format_spec.rb
+++ b/spec/mixlib/versioning/format_spec.rb
@@ -1,6 +1,8 @@
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Ryan Hass (<rhass@chef.io>)
 # Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,3 +61,28 @@ describe Mixlib::Versioning::Format do
     end # describe
   end # describe ".for"
 end # describe Mixlib::Versioning::Format
+
+describe Mixlib::Versioning do
+  versions = [
+    "1", "1.0.0",
+    "1.2", "1.2.0"
+  ]
+
+  describe "#==" do
+    formats = described_class::DEFAULT_FORMATS.select do |klass|
+      unless klass.name == "Mixlib::Versioning::Format::PartialSemVer" || klass.name == "Mixlib::Versioning::Format::GitDescribe"
+        klass
+      end
+    end
+
+    formats.each do |format|
+      context "#{format}" do
+        versions.each_slice(2) do |a, b|
+          it "parsed value #{a} is equal to #{format} parsed value #{b}" do
+            expect(described_class.parse(a) == format.new(b)).to be true
+          end
+        end
+      end # context
+    end # formats.each
+  end # describe "#=="
+end # describe Mixlib::Version

--- a/spec/mixlib/versioning/format_spec.rb
+++ b/spec/mixlib/versioning/format_spec.rb
@@ -26,7 +26,7 @@ describe Mixlib::Versioning::Format do
     let(:version_string) { "11.0.0" }
 
     it "descendants must override #parse" do
-      expect { subject }.to raise_error
+      expect { subject }.to raise_error(StandardError)
     end
   end
 

--- a/spec/support/shared_examples/behaviors/comparable.rb
+++ b/spec/support/shared_examples/behaviors/comparable.rb
@@ -21,7 +21,7 @@ shared_examples "comparable" do |version_matrix|
     version_matrix.each_slice(2) do |a, b|
       it "confirms that #{a} is less-than #{b}" do
         expect(described_class.new(a) < b).to be true
-        expect(described_class.new(a) > b).to be false
+        expect(b < described_class.new(a)).to be false
       end
     end
   end
@@ -31,8 +31,8 @@ shared_examples "comparable" do |version_matrix|
       it "confirms that #{a} less-than or equal to #{b}" do
         expect(described_class.new(a) <= b).to be true
         expect(described_class.new(a) <= a).to be true
-        expect(described_class.new(a) > b).to be false
-        expect(described_class.new(a) == b).to be false
+        expect(b <= described_class.new(a)).to be false
+        expect(b < described_class.new(a)).to be false
       end
     end
   end
@@ -51,7 +51,7 @@ shared_examples "comparable" do |version_matrix|
     version_matrix.reverse.each_slice(2) do |a, b|
       it "confirms that #{a} is greather-than #{b}" do
         expect(described_class.new(a) > b).to be true
-        expect(described_class.new(a) < b).to be false
+        expect(b > described_class.new(a)).to be false
       end
     end
   end
@@ -61,8 +61,8 @@ shared_examples "comparable" do |version_matrix|
       it "confirms that #{a} greater-than or equal to #{b}" do
         expect(described_class.new(a) >= b).to be true
         expect(described_class.new(a) >= a).to be true
-        expect(described_class.new(a) < b).to be false
-        expect(described_class.new(a) == b).to be false
+        expect(b >= described_class.new(a)).to be false
+        expect(b > described_class.new(a)).to be false
       end
     end
   end

--- a/spec/support/shared_examples/behaviors/comparable_types.rb
+++ b/spec/support/shared_examples/behaviors/comparable_types.rb
@@ -1,0 +1,56 @@
+#
+# Author:: Krzysztof Wilczynski (<kwilczynski@chef.io>)
+# Author:: Ryan Hass (<rhass@chef.io>)
+# Copyright:: Copyright (c) 2014, 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+shared_examples "comparable_types" do |version_matrix|
+  describe "#<" do
+    version_matrix.each_slice(2) do |a, b|
+      it "confirms that #{a} is less-than #{b}" do
+        expect(described_class.new(a) < b[:class].new(b[:value])).to be true
+        expect(b[:class].new(b[:value]) < described_class.new(a)).to be false
+      end
+    end
+  end
+
+  describe "#<=" do
+    version_matrix.each_slice(2) do |a, b|
+      it "confirms that #{a} less-than or equal to #{b}" do
+        expect(described_class.new(a) <= b[:class].new(b[:value])).to be true
+        expect(b[:class].new("#{b[:value]}") <= described_class.new(a)).to be false
+      end
+    end
+  end
+
+  describe "#>" do
+    version_matrix.each_slice(2) do |a, b|
+      it "confirms that #{a} is greater-than #{b}" do
+        expect(b[:class].new(b[:value]) > described_class.new(a)).to be true
+        expect(described_class.new(a) > b[:class].new(b[:value])).to be false
+      end
+    end
+  end
+
+  describe "#>=" do
+    version_matrix.each_slice(2) do |a, b|
+      it "confirms that #{a} greater-than or equal to #{b}" do
+        expect(b[:class].new(b[:value]) >= described_class.new(a)).to be true
+        expect(described_class.new(a) >= b[:class].new(b[:value])).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for partial version strings to the RubyGems version type to more closely imitate the Gem::Version behavior.

This PR also fixes a bug when comparing Rubygems version types against `semver` or `opscode_semver` in which the value of `iteration` was always assigned to `0` which would result in incorrect comparison results. We also now correctly parse git style version strings when the rubygems formatter is specified and reject the git hash. This replicates the `Gem::Version.new` behavior more closely but in a more usable form.


- Fixes #15

What this PR does not do:
- Add partial version support to `opscode_semver`
- Add partial version support to `semver` (violates semver anyway)

The following items will be addressed in a different PR:
- Add pessimistic operator support `>~`
- Add `satisfies?`

/cc @chef/engineering-services