### PR TITLE
Remove last remnants of GitHub changelog generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@
 - Use Expeditor for version bumping and CHANGELOG generation [#23](https://github.com/chef/mixlib-versioning/pull/23) ([schisamo](https://github.com/schisamo))
 <!-- latest_release -->
 
-<!-- release_rollup -->
-### Changes since latest stable release
-
-#### Merged Pull Requests
-- Use Expeditor for version bumping and CHANGELOG generation [#23](https://github.com/chef/mixlib-versioning/pull/23) ([schisamo](https://github.com/schisamo)) <!-- 1.2.1 -->
-<!-- release_rollup -->
-
 ## [1.1.0](https://github.com/chef/mixlib-versioning/tree/v1.1.0) (2015-06-15)
 
 #### New features

--- a/Rakefile
+++ b/Rakefile
@@ -13,17 +13,6 @@ RuboCop::RakeTask.new(:style)
 require "yard"
 YARD::Rake::YardocTask.new(:doc)
 
-begin
-  require "github_changelog_generator/task"
-
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.issues = false
-    config.future_release = Mixlib::Versioning::VERSION
-  end
-rescue LoadError
-  puts "github_changelog_generator is not available. gem install github_changelog_generator to generate changelogs"
-end
-
 namespace :travis do
   desc "Run tests on Travis"
   task ci: [:style, :unit]


### PR DESCRIPTION
This was inadvertently missed in chef/mixlib-versioning#23

Signed-off-by: Seth Chisamore <schisamo@chef.io>