### PR TITLE
Issue 25/support older rubies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/tmp
 test/version_tmp
 tmp
 bin/
+Gemfile.local

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ cache: bundler
 
 matrix:
   include:
+    - rvm: 1.9.3
+    - rvm: 2.0
+    - rvm: 2.2.7
     - rvm: 2.3.4
     - rvm: 2.4.1
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ cache: bundler
 matrix:
   include:
     - rvm: 1.9.3
+      bundler_args: --without chefstyle functional --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+      script:
+        - bundle exec rake unit
+        - bundle exec rake functional
     - rvm: 2.0
     - rvm: 2.2.7
     - rvm: 2.3.4

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,21 @@ group :docs do
   gem "redcarpet",     "~> 2.2"
   gem "github-markup", "~> 0.7"
 end
+
+group :test, :development do
+  gem "rspec", "~> 3.0"
+  gem "rspec-its"
+  gem "rake", "~> 12"
+end
+
+if RUBY_VERSION =~ /^2/
+  group :chefstyle do
+    gem "chefstyle"
+  end
+end
+
+instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into Gemfile.local
+eval(IO.read(__FILE__ + ".local"), binding) if File.exist?(__FILE__ + ".local")

--- a/Rakefile
+++ b/Rakefile
@@ -5,17 +5,26 @@ require "mixlib/versioning/version"
 
 RSpec::Core::RakeTask.new(:unit)
 
-require "chefstyle"
-require "rubocop/rake_task"
-desc "Run Ruby style checks"
-RuboCop::RakeTask.new(:style)
+begin
+  require "chefstyle"
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new(:style) do |task|
+    task.options << "--display-cop-names"
+  end
+rescue LoadError
+  puts "chefstyle gem is not installed"
+end
 
 require "yard"
 YARD::Rake::YardocTask.new(:doc)
 
+# ChefStyle requires Ruby version 2.x and later, and we skip the gem install/load for 1.9.x
+task_list = [:unit]
+task_list.insert(:style) if RUBY_VERSION =~ /^2/
+
 namespace :travis do
   desc "Run tests on Travis"
-  task ci: [:style, :unit]
+  task ci: task_list
 end
 
-task default: [:style, :unit]
+task default: task_list

--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/mixlib-versioning"
   spec.license       = "Apache 2.0"
 
-  spec.required_ruby_version = ">= 2.2"
+  spec.required_ruby_version = '>= 1.9'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -19,10 +19,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-
-  # Development dependencies
-  spec.add_development_dependency "chefstyle"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-its"
-  spec.add_development_dependency "rake", "~> 12"
 end


### PR DESCRIPTION
Ruby 1.9.3 support is required to facilitate migrations off older versions of Chef.

This reverts a cset which pinned Ruby to 2.2 and later, and went out in the recent release of the Gem. Additionally, this adds Ruby 1.9.3 to the Travis test matrix to help validate everything as working.