### PR TITLE
Don't ship the dev and test deps in the gem artifact

### DIFF
--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/mixlib-versioning"
   spec.license       = "Apache-2.0"
 
-  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
There's no need for dev and test deps in the gem artifact. Just ship the
minimal libraries.

Signed-off-by: Tim Smith <tsmith@chef.io>