### PR TITLE
Support Ruby 2+ in the gemspec

### DIFF
--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -15,4 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   spec.require_paths = ["lib"]
+
+  # we support EOL ruby because we use this in chef_client_updater cookbook with very old Chef / Ruby releases
+  spec.required_ruby_version = ">= 2.0"
 end


### PR DESCRIPTION
This serves mostly as a reminder that this is a dep on
chef_client_updater and needs to support ancient Ruby releases until the
time we decide to kill that upgrade path off.

Signed-off-by: Tim Smith <tsmith@chef.io>