### PR TITLE
Substitute require for require_relative

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please refer to https://github.com/chef/chef/blob/master/CONTRIBUTING.md

--- a/lib/mixlib/versioning.rb
+++ b/lib/mixlib/versioning.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require "mixlib/versioning/exceptions"
-require "mixlib/versioning/format"
+require_relative "versioning/exceptions"
+require_relative "versioning/format"
 
 module Mixlib
   # @author Seth Chisamore (<schisamo@chef.io>)

--- a/lib/mixlib/versioning/format.rb
+++ b/lib/mixlib/versioning/format.rb
@@ -16,11 +16,11 @@
 # limitations under the License.
 #
 
-require "mixlib/versioning/format/git_describe"
-require "mixlib/versioning/format/opscode_semver"
-require "mixlib/versioning/format/rubygems"
-require "mixlib/versioning/format/semver"
-require "mixlib/versioning/format/partial_semver"
+require_relative "format/git_describe"
+require_relative "format/opscode_semver"
+require_relative "format/rubygems"
+require_relative "format/semver"
+require_relative "format/partial_semver"
 
 module Mixlib
   class Versioning

--- a/lib/mixlib/versioning/format/opscode_semver.rb
+++ b/lib/mixlib/versioning/format/opscode_semver.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require "mixlib/versioning/format/semver"
+require_relative "semver"
 
 module Mixlib
   class Versioning


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>