### PR TITLE
Add tests for Workstation Date-build format

### DIFF
--- a/spec/mixlib/versioning/versioning_spec.rb
+++ b/spec/mixlib/versioning/versioning_spec.rb
@@ -95,6 +95,8 @@ describe Mixlib::Versioning do
         "10.18.2.poop-1" => Mixlib::Versioning::Format::Rubygems,
 
         "12.1.1+20130311134422" => Mixlib::Versioning::Format::OpscodeSemVer,
+        "2020.4.100" => Mixlib::Versioning::Format::SemVer, # Workstation date+build format
+        "2020.4.100+20200414223557" => Mixlib::Versioning::Format::OpscodeSemVer, # Workstation date+build+prerelease format
         "12.1.1-rc.3+20130311134422" => Mixlib::Versioning::Format::OpscodeSemVer,
         "12.1.1+20130308110833.git.2.94a1dde" => Mixlib::Versioning::Format::OpscodeSemVer,
 


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

Chef Workstation is changing its versioning format slightly to be YYYY.M.BUILD(+PRERELEASE?). This PR adds a pair of tests to verify that the format is recognized by the library.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
