### PR TITLE
Remove legacy encoding comment

### DIFF
--- a/mixlib-versioning.gemspec
+++ b/mixlib-versioning.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "mixlib/versioning/version"


### PR DESCRIPTION
Not needed on Ruby 2.0+

Signed-off-by: Tim Smith <tsmith@chef.io>